### PR TITLE
Add smooth volume and brightness control

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,48 +1,57 @@
 # Touchpad Gesture Customization
+
 This extension modifies and extends existing touchpad gestures on GNOME using Wayland. This project is a fork of [gnome-gesture-improvements](https://github.com/harshadgavali/gnome-gesture-improvements). Since the original project seems to be no longer maintained, I setup this project with the aim of taking over the development and maintenance of this wonderful extension that I relied on for daily use.
 
 **Note**: I have removed the support for X11 since I only use Wayland, but this can be added again in the future if needed and if someone is willing to support this.
 
 ## Installation
+
 ### From GNOME Extensions Website
+
 <a href="https://extensions.gnome.org/extension/7850/touchpad-gesture-customization/">
 <img src="https://github.com/andyholmes/gnome-shell-extensions-badge/raw/master/get-it-on-ego.svg" alt="Get it on EGO" width="200" />
 </a>
 
 ### Manually
+
 1. Install extension
+
 ```
 git clone https://github.com/HieuTNg/touchpad-gesture-customization.git
 cd touchpad-gesture-customization
 npm install
 npm run update
 ```
+
 2. Log out and log in
 3. Enable extension via extensions app or via command line
+
 ```
 gnome-extensions enable touchpad-gesture-customization@coooolapps.com
 ```
 
 ## Gestures (including built-in ones)
+
 | Swipe Gesture                           | Modes    | Fingers  | Direction           |
 | :-------------------------------------- | :------- | :------- | :------------------ |
 | Desktop/Overview/AppGrid navigation     | Any      | 3/4/both | Vertical/Horizontal |
-| Switch workspaces                       | Overview | 2|3|4    | Horizontal          |
+| Switch workspaces                       | Overview | 2/3/4    | Horizontal          |
 | Switch workspaces                       | Any      | 3/4/both | Vertical/Horizontal |
 | Switch app pages                        | AppGrid  | 2/3      | Horizontal          |
 | Switch windows                          | Desktop  | 3/4/both | Vertical/Horizontal |
 | Unmaximize/maximize/fullscreen a window | Desktop  | 3/4/both | Vertical            |
 | Minimize a window                       | Desktop  | 3/4/both | Vertical            |
-| Snap/half-tile a window                 | Desktop  | 3/4/both | Vertical (*)        |
-| Volume Control (experimental)           | Desktop  | 3/4/both | Vertical/Horizontal |
+| Snap/half-tile a window                 | Desktop  | 3/4/both | Vertical (\*)       |
+| Volume Control                          | Desktop  | 3/4/both | Vertical/Horizontal |
+| Brightness Control                      | Desktop  | 3/4/both | Vertical/Horizontal |
 
 | Pinch Gesture      | Modes   | Fingers |
 | :----------------- | :------ | :------ |
-| Show Desktop (*)   | Desktop | 3/4     |
+| Show Desktop (\*)  | Desktop | 3/4     |
 | Close Window       | Desktop | 3/4     |
 | Close Tab/Document | Desktop | 3/4     |
 
-| Application Gestures (Configurable) (*)          |
+| Application Gestures (Configurable) (\*)         |
 | :----------------------------------------------- |
 | Go back or forward in browser tab                |
 | Page up/down                                     |
@@ -51,28 +60,39 @@ gnome-extensions enable touchpad-gesture-customization@coooolapps.com
 | Change tabs                                      |
 
 #### For activating snapping/tiling gesture (inverted T gesture)
+
 1. Do a 3/4-fingers vertical swipe downward gesture on a unmaximized window but don't release the gesture
 2. Wait a few milliseconds
 3. Do a 3/4-fingers horizontal swipe gesture to tile a window to either side of the screen
 
 #### For activating application gesture
+
 1. Activating a 3/4-fingers hold gesture on touchpad by pressing your fingers on touchpad but don't release the gesture
 2. Wait a few milliseconds
 3. Do a 3/4-fingers horizontal swipe gesture to activate application gesture (an arrow animation cicle will appear)
 
 #### Application Gesture Notes
-* For horizontal gestures, application gesture only works if 3/4-fingers horizontal swipe is set to **Window Swithing**
-* Application gesture also supports vertical swipe but is still experimental and requires users to turn off other actions for 3/4-figners vertical swipe (i.e. set the action to None).
+
+- For horizontal gestures, application gesture only works if 3/4-fingers horizontal swipe is set to **Window Switching**
+- Application gesture also supports vertical swipe but is still experimental and requires users to turn off other actions for 3/4-figners vertical swipe (i.e. set the action to None).
 
 #### Notes
-* Enbaling minimising window gesture for Window Manipulation will disable snapping/tiling gesture.
-* If you are using an older version of GNOME, there might be a bug which prevent the extension from detecting **hold and swipe gesture** and **pich gesture**. If you face this problem, the gesture can only work if the mouse pointer is pointed at the desktop or top panel.
+
+- Enabling minimising window gesture for Window Manipulation will disable snapping/tiling gesture.
+- If you are using an older version of GNOME, there might be a bug which prevent the extension from detecting **hold and swipe gesture** and **pinch gesture**. If you face this problem, the gesture can only work if the mouse pointer is pointed at the desktop or top panel.
 
 ## Customization
-* To switch to windows from *all* workspaces using 3-fingers swipes, run 
+
+- To switch to windows from _all_ workspaces using 3-fingers swipes, run
+
 ```
 gsettings set org.gnome.shell.window-switcher current-workspace-only false
 ```
 
 # Acknowledgement
+
 Massive thanks to the original author and everyone who has contributed to the original project to bring us this wonderful GNOME extension.
+
+[Screen Brightness Governor](https://github.com/inbalboa/gnome-brightness-governor) - brightness control code.
+
+[Volume Scroller](https://github.com/francislavoie/gnome-shell-volume-scroller) - volume control code.

--- a/extension/common/settings.ts
+++ b/extension/common/settings.ts
@@ -14,7 +14,8 @@ export enum SwipeGestureType {
     WORKSPACE_SWITCHING = 2,
     WINDOW_SWITCHING = 3,
     VOLUME_CONTROL = 4,
-    WINDOW_MANIPULATION = 5,
+    BRIGHTNESS_CONTROL = 5,
+    WINDOW_MANIPULATION = 6,
 }
 
 export enum OverviewNavigationState {
@@ -35,6 +36,8 @@ export enum ForwardBackKeyBinds {
 export type BooleanSettingsKeys =
     | 'allow-minimize-window'
     | 'follow-natural-scroll'
+    | 'invert-volume-gesture-direction'
+    | 'invert-brightness-gesture-direction'
     | 'enable-forward-back-gesture'
     | 'default-overview-gesture-direction'
     | 'enable-vertical-app-gesture';
@@ -44,7 +47,8 @@ export type IntegerSettingsKeys = 'alttab-delay' | 'hold-swipe-delay-duration';
 export type DoubleSettingsKeys =
     | 'touchpad-speed-scale'
     | 'touchpad-pinch-speed'
-    | 'volume-control-speed';
+    | 'volume-control-speed'
+    | 'brightness-control-speed';
 
 export type EnumSettingsKeys =
     | 'vertical-swipe-3-fingers-gesture'
@@ -71,7 +75,8 @@ export type AllUIObjectKeys =
     | AllSettingsKeys
     | 'touchpad-speed-scale_display-value'
     | 'touchpad-pinch-speed_display-value'
-    | 'volume-control-speed_display-value';
+    | 'volume-control-speed_display-value'
+    | 'brightness-control-speed_display-value';
 
 type Enum_Functions<K extends EnumSettingsKeys, T> = {
     get_enum(key: K): T;

--- a/extension/constants.ts
+++ b/extension/constants.ts
@@ -9,6 +9,8 @@ export const TouchpadConstants = {
     PINCH_MULTIPLIER: 1,
     DEFAULT_VOLUME_CONTROL_MULTIPLIER: 1,
     VOLUME_CONTROL_MULTIPLIER: 1,
+    DEFAULT_BRIGHTNESS_CONTROL_MULTIPLIER: 1,
+    BRIGHTNESS_CONTROL_MULTIPLIER: 1,
     DRAG_THRESHOLD_DISTANCE: 16,
     TOUCHPAD_BASE_HEIGHT: 300,
     TOUCHPAD_BASE_WIDTH: 400,
@@ -36,7 +38,9 @@ export const ExtSettings = {
     FOLLOW_NATURAL_SCROLL: true,
     APP_GESTURES: false,
     DEFAULT_OVERVIEW_GESTURE_DIRECTION: true,
+    INVERT_VOLUME_DIRECTION: false,
+    INVERT_BRIGHTNESS_DIRECTION: false,
 };
 
 export const RELOAD_DELAY = 150; // reload extension delay in ms
-export const WIGET_SHOWING_DURATION = 100; // animation duration for showing widget
+export const WIDGET_SHOWING_DURATION = 100; // animation duration for showing widget

--- a/extension/extension.ts
+++ b/extension/extension.ts
@@ -276,7 +276,7 @@ export default class TouchpadGestureCustomization extends Extension {
 
             // Enable horizontal swipe for overview navigation
             if (horizontalVolumeControlFingers?.length) {
-                volumeControlGestureExtension?.setHorizontalSwipeTracker(
+                volumeControlGestureExtension.setHorizontalSwipeTracker(
                     horizontalVolumeControlFingers
                 );
             }

--- a/extension/extension.ts
+++ b/extension/extension.ts
@@ -22,6 +22,7 @@ import {SnapWindowExtension} from './src/snapWidnow.js';
 import {ShowDesktopExtension} from './src/pinchGestures/showDesktop.js';
 import {CloseWindowExtension} from './src/pinchGestures/closeWindow.js';
 import {VolumeControlGestureExtension} from './src/volumeControl.js';
+import {BrightnessControlGestureExtension} from './src/brightnessControl.js';
 
 export default class TouchpadGestureCustomization extends Extension {
     private _extensions: ISubExtension[];
@@ -39,6 +40,7 @@ export default class TouchpadGestureCustomization extends Extension {
             'alttab-delay',
             'touchpad-pinch-speed',
             'volume-control-speed',
+            'brightness-control-speed',
         ];
     }
 
@@ -285,6 +287,42 @@ export default class TouchpadGestureCustomization extends Extension {
         }
 
         /**
+         * Brightness Control
+         */
+
+        const verticalBrightnessControlFingers = verticalSwipeToFingersMap.get(
+            SwipeGestureType.BRIGHTNESS_CONTROL
+        );
+        const horizontalBrightnessControlFingers =
+            horizontalSwipeToFingersMap.get(
+                SwipeGestureType.BRIGHTNESS_CONTROL
+            );
+
+        if (
+            verticalBrightnessControlFingers?.length ||
+            horizontalBrightnessControlFingers?.length
+        ) {
+            const brightnessControlGestureExtension =
+                new BrightnessControlGestureExtension();
+
+            // Enable vertical swipe for overview navigation
+            if (verticalBrightnessControlFingers?.length) {
+                brightnessControlGestureExtension.setVerticalSwipeTracker(
+                    verticalBrightnessControlFingers
+                );
+            }
+
+            // Enable horizontal swipe for overview navigation
+            if (horizontalBrightnessControlFingers?.length) {
+                brightnessControlGestureExtension.setHorizontalSwipeTracker(
+                    horizontalBrightnessControlFingers
+                );
+            }
+
+            this._extensions.push(brightnessControlGestureExtension);
+        }
+
+        /**
          * App Gestures
          */
         if (this.settings.get_boolean('enable-forward-back-gesture')) {
@@ -384,6 +422,12 @@ export default class TouchpadGestureCustomization extends Extension {
                 this.settings.get_boolean('follow-natural-scroll');
             Constants.ExtSettings.DEFAULT_OVERVIEW_GESTURE_DIRECTION =
                 this.settings.get_boolean('default-overview-gesture-direction');
+            Constants.ExtSettings.INVERT_VOLUME_DIRECTION =
+                this.settings.get_boolean('invert-volume-gesture-direction');
+            Constants.ExtSettings.INVERT_BRIGHTNESS_DIRECTION =
+                this.settings.get_boolean(
+                    'invert-brightness-gesture-direction'
+                );
             Constants.ExtSettings.APP_GESTURES = this.settings.get_boolean(
                 'enable-forward-back-gesture'
             );
@@ -397,6 +441,10 @@ export default class TouchpadGestureCustomization extends Extension {
             Constants.TouchpadConstants.VOLUME_CONTROL_MULTIPLIER =
                 Constants.TouchpadConstants.DEFAULT_VOLUME_CONTROL_MULTIPLIER *
                 this.settings.get_double('volume-control-speed');
+            Constants.TouchpadConstants.BRIGHTNESS_CONTROL_MULTIPLIER =
+                Constants.TouchpadConstants
+                    .DEFAULT_BRIGHTNESS_CONTROL_MULTIPLIER *
+                this.settings.get_double('brightness-control-speed');
             Constants.AltTabConstants.DELAY_DURATION =
                 this.settings.get_int('alttab-delay');
             Constants.TouchpadConstants.HOLD_SWIPE_DELAY_DURATION =

--- a/extension/prefs/pref.ts
+++ b/extension/prefs/pref.ts
@@ -127,6 +127,12 @@ function bindPrefsSettings(builder: GtkBuilder, settings: Gio.Settings) {
         settings,
         builder
     );
+    display_in_log_scale(
+        'brightness-control-speed',
+        'brightness-control-speed_display-value',
+        settings,
+        builder
+    );
 
     bind_int_value('alttab-delay', settings, builder);
     bind_int_value('hold-swipe-delay-duration', settings, builder);
@@ -137,6 +143,12 @@ function bindPrefsSettings(builder: GtkBuilder, settings: Gio.Settings) {
         settings,
         builder,
         Gio.SettingsBindFlags.INVERT_BOOLEAN
+    );
+    bind_boolean_value('invert-volume-gesture-direction', settings, builder);
+    bind_boolean_value(
+        'invert-brightness-gesture-direction',
+        settings,
+        builder
     );
     bind_boolean_value('enable-vertical-app-gesture', settings, builder);
 

--- a/extension/schemas/org.gnome.shell.extensions.touchpad-gesture-customization.gschema.xml
+++ b/extension/schemas/org.gnome.shell.extensions.touchpad-gesture-customization.gschema.xml
@@ -17,7 +17,8 @@
     <value value='2' nick='WORKSPACE_SWITCHING' />
     <value value='3' nick='WINDOW_SWITCHING' />
     <value value='4' nick='VOLUME_CONTROL' />
-    <value value='5' nick='WINDOW_MANIPULATION' />
+    <value value='5' nick='BRIGHTNESS_CONTROL' />
+    <value value='6' nick='WINDOW_MANIPULATION' />
   </enum>
   <enum id='org.gnome.shell.extensions.touchpad-gesture-customization.horizontal-swipe-gestures'>
     <value value='0' nick='NONE' />
@@ -25,6 +26,7 @@
     <value value='2' nick='WORKSPACE_SWITCHING' />
     <value value='3' nick='WINDOW_SWITCHING' />
     <value value='4' nick='VOLUME_CONTROL' />
+    <value value='5' nick='BRIGHTNESS_CONTROL' />
   </enum>
   <schema id="org.gnome.shell.extensions.touchpad-gesture-customization" path="/org/gnome/shell/extensions/touchpad-gesture-customization/">
     <!-- See also: https://docs.gtk.org/glib/gvariant-format-strings.html -->
@@ -35,6 +37,9 @@
       <default>1.0</default>
     </key>
     <key name="volume-control-speed" type="d">
+      <default>1.0</default>
+    </key>
+    <key name="brightness-control-speed" type="d">
       <default>1.0</default>
     </key>
     <key name="alttab-delay" type="i">
@@ -54,6 +59,14 @@
     <key name='default-overview-gesture-direction' type='b'>
       <default>true</default>
       <description>Default direction for overview navigation</description>
+    </key>
+    <key name='invert-volume-gesture-direction' type='b'>
+      <default>true</default>
+      <description>Whether to invert volume control gesture direction</description>
+    </key>
+    <key name='invert-brightness-gesture-direction' type='b'>
+      <default>true</default>
+      <description>Whether to invert brightness control gesture direction</description>
     </key>
     <key name='enable-forward-back-gesture' type='b'>
       <default>false</default>
@@ -91,7 +104,7 @@
       <default>'WINDOW_PICKER_ONLY'</default>
       <description>Customization for overview and app-grid navigation using vertical swipe</description>
     </key>
-    <!-- 
+    <!--
       0 -> Default
       1 -> Forward/Back
       2 -> PageUP/PageDown

--- a/extension/src/animations/arrow.ts
+++ b/extension/src/animations/arrow.ts
@@ -4,7 +4,7 @@ import St from 'gi://St';
 import GObject from 'gi://GObject';
 import * as Util from 'resource:///org/gnome/shell/misc/util.js';
 import {easeActor} from '../utils/environment.js';
-import {WIGET_SHOWING_DURATION} from '../../constants.js';
+import {WIDGET_SHOWING_DURATION} from '../../constants.js';
 
 declare type IconList =
     | 'arrow1-right-symbolic.svg'
@@ -103,7 +103,7 @@ export const ArrowIconAnimation = GObject.registerClass(
             easeActor(this as St.Widget, {
                 opacity: 255,
                 mode: Clutter.AnimationMode.EASE_OUT_QUAD,
-                duration: WIGET_SHOWING_DURATION,
+                duration: WIDGET_SHOWING_DURATION,
             });
 
             this._arrow_icon.set_gicon(

--- a/extension/src/brightnessControl.ts
+++ b/extension/src/brightnessControl.ts
@@ -1,47 +1,46 @@
 import Clutter from 'gi://Clutter';
 import Shell from 'gi://Shell';
 import Gio from 'gi://Gio';
-import Gvc from 'gi://Gvc';
 import * as Main from 'resource:///org/gnome/shell/ui/main.js';
-import * as Volume from 'resource:///org/gnome/shell/ui/status/volume.js';
+import {loadInterfaceXML} from 'resource:///org/gnome/shell/misc/fileUtils.js';
 import {SwipeTracker} from 'resource:///org/gnome/shell/ui/swipeTracker.js';
 import {createSwipeTracker} from './swipeTracker.js';
 import {ExtSettings, TouchpadConstants} from '../constants.js';
 
-const VolumeIcons = [
-    'audio-volume-muted-symbolic',
-    'audio-volume-low-symbolic',
-    'audio-volume-medium-symbolic',
-    'audio-volume-high-symbolic',
-];
+const BrightnessProxy = Gio.DBusProxy.makeProxyWrapper(
+    loadInterfaceXML('org.gnome.SettingsDaemon.Power.Screen')
+) as unknown as new (
+    connection: Gio.DBusConnection,
+    name: string | null,
+    objectPath: string,
+    callback?: (proxy: Gio.DBusProxy, error: Error | null) => void
+) => Gio.DBusProxy;
 
-export class VolumeControlGestureExtension implements ISubExtension {
+export class BrightnessControlGestureExtension implements ISubExtension {
     private _verticalSwipeTracker?: SwipeTracker;
     private _horizontalSwipeTracker?: SwipeTracker;
     private _verticalConnectHandlers?: number[];
     private _horizontalConnectHandlers?: number[];
-    private _controller?: Gvc.MixerControl;
-    private _sink?: Gvc.MixerStream;
-    private _maxVolume!: number;
-    private _sinkChangeBinding!: number;
+    private _brightnessProxy?: Gio.DBusProxy;
     private _lastOsdShowTimestamp: number = 0;
 
     apply() {
-        this._controller = Volume.getMixerControl();
-
-        this._maxVolume = this._controller.get_vol_max_norm();
-
-        this._sink = this._controller.get_default_sink();
-        this._sinkChangeBinding = this._controller.connect(
-            'default-sink-changed',
-            this._handleSinkChange.bind(this)
+        this._brightnessProxy = new BrightnessProxy(
+            Gio.DBus.session,
+            'org.gnome.SettingsDaemon.Power',
+            '/org/gnome/SettingsDaemon/Power',
+            (proxy, error) => {
+                if (error)
+                    console.error(
+                        `Failed to connect to the ${proxy.g_interface_name} D-Bus interface`,
+                        error
+                    );
+            }
         );
     }
 
     destroy(): void {
-        this._controller?.disconnect(this._sinkChangeBinding);
-        delete this._controller;
-        delete this._sink;
+        delete this._brightnessProxy;
 
         this._verticalConnectHandlers?.forEach(handle =>
             this._verticalSwipeTracker?.disconnect(handle)
@@ -62,8 +61,8 @@ export class VolumeControlGestureExtension implements ISubExtension {
             nfingers,
             Shell.ActionMode.NORMAL | Shell.ActionMode.OVERVIEW,
             Clutter.Orientation.VERTICAL,
-            !ExtSettings.INVERT_VOLUME_DIRECTION,
-            TouchpadConstants.VOLUME_CONTROL_MULTIPLIER,
+            !ExtSettings.INVERT_BRIGHTNESS_DIRECTION,
+            TouchpadConstants.BRIGHTNESS_CONTROL_MULTIPLIER * 100,
             {allowTouch: false}
         );
 
@@ -89,8 +88,8 @@ export class VolumeControlGestureExtension implements ISubExtension {
             nfingers,
             Shell.ActionMode.NORMAL | Shell.ActionMode.OVERVIEW,
             Clutter.Orientation.HORIZONTAL,
-            !ExtSettings.INVERT_VOLUME_DIRECTION,
-            TouchpadConstants.VOLUME_CONTROL_MULTIPLIER,
+            !ExtSettings.INVERT_BRIGHTNESS_DIRECTION,
+            TouchpadConstants.BRIGHTNESS_CONTROL_MULTIPLIER * 100,
             {allowTouch: false}
         );
 
@@ -110,11 +109,22 @@ export class VolumeControlGestureExtension implements ISubExtension {
         ];
     }
 
-    _handleSinkChange(controller: Gvc.MixerControl, id: number) {
-        this._sink = controller.lookup_stream_id(id);
+    get _brightness() {
+        return this._brightnessProxy?.Brightness ?? 0;
     }
 
-    _showOsd(volume: number) {
+    set _brightness(value: number) {
+        if (
+            this._brightnessProxy === undefined ||
+            this._brightnessProxy.Brightness === null
+        ) {
+            return;
+        }
+
+        this._brightnessProxy.Brightness = value;
+    }
+
+    _showOsd(brightness: number) {
         // If osd is updated too frequently, it may lag or freeze, so cap it to 30 fps
         const nowTimestamp = new Date().getTime();
 
@@ -124,45 +134,26 @@ export class VolumeControlGestureExtension implements ISubExtension {
 
         this._lastOsdShowTimestamp = nowTimestamp;
 
-        const percentage = volume / this._maxVolume;
-        const iconIndex =
-            volume === 0 ? 0 : Math.clamp(Math.floor(3 * percentage + 1), 1, 3);
+        const percentage = brightness / 100;
 
         const monitor = -1; // Display volume window on all monitors
-        const icon = Gio.Icon.new_for_string(VolumeIcons[iconIndex]);
-        const label = this._sink?.get_port().human_port ?? '';
+        const icon = Gio.Icon.new_for_string('display-brightness-symbolic');
 
-        Main.osdWindowManager.show(monitor, icon, label, percentage);
+        Main.osdWindowManager.show(monitor, icon, null, percentage);
     }
 
     _gestureBegin(_tracker: SwipeTracker): void {
-        if (this._sink === undefined) {
-            return;
-        }
-
         _tracker.confirmSwipe(
             global.screen_height,
-            [0, 1], // no snapping is needed as volume change is continuous, but this will automatically clamp progress to [0, 1]
-            this._sink.volume / this._maxVolume, // current normalized volume
+            [0, 100], // no snapping is needed as brightness change is continuous, but this will automatically clamp progress to [0, 100]
+            this._brightness, // current brightness
             0 // can be whatever
         );
     }
 
     _gestureUpdate(_tracker: SwipeTracker, progress: number): void {
-        if (this._sink === undefined) {
-            return;
-        }
-
-        const volume = progress * this._maxVolume;
-
-        if (volume > 0) {
-            this._sink.change_is_muted(false);
-        }
-
-        this._sink.volume = volume;
-        this._sink.push_volume();
-
-        this._showOsd(volume);
+        this._brightness = progress;
+        this._showOsd(progress);
     }
 
     _gestureEnd(

--- a/extension/src/brightnessControl.ts
+++ b/extension/src/brightnessControl.ts
@@ -152,8 +152,10 @@ export class BrightnessControlGestureExtension implements ISubExtension {
     }
 
     _gestureUpdate(_tracker: SwipeTracker, progress: number): void {
-        this._brightness = progress;
-        this._showOsd(progress);
+        // Round instead of truncating so that brightness changes sync exactly with extensions like "OSD Volume Number"
+        const brightness = Math.round(progress);
+        this._brightness = brightness;
+        this._showOsd(brightness);
     }
 
     _gestureEnd(

--- a/extension/src/pinchGestures/closeWindow.ts
+++ b/extension/src/pinchGestures/closeWindow.ts
@@ -5,7 +5,7 @@ import St from 'gi://St';
 import * as Main from 'resource:///org/gnome/shell/ui/main.js';
 import * as Util from 'resource:///org/gnome/shell/misc/util.js';
 import {PinchGestureType} from '../../common/settings.js';
-import {WIGET_SHOWING_DURATION} from '../../constants.js';
+import {WIDGET_SHOWING_DURATION} from '../../constants.js';
 import {TouchpadPinchGesture} from './pinchTracker.js';
 import {easeActor} from '../utils/environment.js';
 import {getVirtualKeyboard, IVirtualKeyboard} from '../utils/keyboard.js';
@@ -87,7 +87,7 @@ export class CloseWindowExtension implements ISubExtension {
         easeActor(this._preview, {
             opacity: 255,
             mode: Clutter.AnimationMode.EASE_OUT_QUAD,
-            duration: WIGET_SHOWING_DURATION,
+            duration: WIDGET_SHOWING_DURATION,
         });
     }
 

--- a/extension/src/volumeControl.ts
+++ b/extension/src/volumeControl.ts
@@ -1,38 +1,46 @@
 import Clutter from 'gi://Clutter';
 import Shell from 'gi://Shell';
+import Gio from 'gi://Gio';
+import Gvc from 'gi://Gvc';
+import * as Main from 'resource:///org/gnome/shell/ui/main.js';
+import * as Volume from 'resource:///org/gnome/shell/ui/status/volume.js';
 import {SwipeTracker} from 'resource:///org/gnome/shell/ui/swipeTracker.js';
 import {createSwipeTracker} from './swipeTracker.js';
-import {getVirtualKeyboard, IVirtualKeyboard} from './utils/keyboard.js';
 import {TouchpadConstants} from '../constants.js';
 
-enum VolumeGestureState {
-    VOLUME_UP = 1,
-    DEFAULT = 0,
-    VOLUME_DOWN = -1,
-}
+const VolumeIcons = [
+    'audio-volume-muted-symbolic',
+    'audio-volume-low-symbolic',
+    'audio-volume-medium-symbolic',
+    'audio-volume-high-symbolic',
+];
 
 export class VolumeControlGestureExtension implements ISubExtension {
     private _verticalSwipeTracker?: SwipeTracker;
     private _horizontalSwipeTracker?: SwipeTracker;
     private _verticalConnectHandlers?: number[];
     private _horizontalConnectHandlers?: number[];
-    private _keyboard: IVirtualKeyboard;
-    private _volumeGestureState: VolumeGestureState;
-    private _progress = 0;
-
-    constructor() {
-        this._keyboard = getVirtualKeyboard();
-        this._progress = 0;
-        this._volumeGestureState = VolumeGestureState.DEFAULT;
-    }
+    private _controller!: Gvc.MixerControl;
+    private _sink!: Gvc.MixerStream;
+    private _maxVolume!: number;
+    private _sinkChangeBinding!: number;
+    private _lastOsdShowTimestamp: number = 0;
 
     apply() {
-        this._keyboard = getVirtualKeyboard();
-        this._progress = 0;
-        this._volumeGestureState = VolumeGestureState.DEFAULT;
+        this._controller = Volume.getMixerControl();
+
+        this._maxVolume = this._controller.get_vol_max_norm();
+
+        this._sink = this._controller.get_default_sink();
+        this._sinkChangeBinding = this._controller.connect(
+            'default-sink-changed',
+            this._handle_sink_change.bind(this)
+        );
     }
 
     destroy(): void {
+        this._controller.disconnect(this._sinkChangeBinding);
+
         this._verticalConnectHandlers?.forEach(handle =>
             this._verticalSwipeTracker?.disconnect(handle)
         );
@@ -44,8 +52,6 @@ export class VolumeControlGestureExtension implements ISubExtension {
         );
         this._horizontalConnectHandlers = undefined;
         this._horizontalSwipeTracker?.destroy();
-
-        this._progress = 0;
     }
 
     setVerticalSwipeTracker(nfingers: number[]) {
@@ -82,7 +88,7 @@ export class VolumeControlGestureExtension implements ISubExtension {
             Shell.ActionMode.NORMAL | Shell.ActionMode.OVERVIEW,
             Clutter.Orientation.HORIZONTAL,
             true,
-            1,
+            TouchpadConstants.VOLUME_CONTROL_MULTIPLIER,
             {allowTouch: false}
         );
 
@@ -102,53 +108,56 @@ export class VolumeControlGestureExtension implements ISubExtension {
         ];
     }
 
+    _handle_sink_change(controller: Gvc.MixerControl, id: number) {
+        this._sink = controller.lookup_stream_id(id);
+    }
+
+    _show_osd(volume: number) {
+        // If osd is updated too frequently, it may lag or freeze, so cap it to 30 fps
+        const nowTimestamp = new Date().getTime();
+
+        if (nowTimestamp - this._lastOsdShowTimestamp < 1000 / 30) {
+            return;
+        }
+
+        this._lastOsdShowTimestamp = nowTimestamp;
+
+        const percentage = volume / this._maxVolume;
+        const iconIndex =
+            volume === 0 ? 0 : Math.clamp(Math.floor(3 * percentage + 1), 1, 3);
+
+        const monitor = -1; // Display volume window on all monitors
+        const icon = Gio.Icon.new_for_string(VolumeIcons[iconIndex]);
+        const label = this._sink.get_port().human_port;
+
+        Main.osdWindowManager.show(monitor, icon, label, percentage);
+    }
+
     _gestureBegin(_tracker: SwipeTracker): void {
-        this._volumeGestureState = VolumeGestureState.DEFAULT;
         _tracker.confirmSwipe(
             global.screen_height,
-            [
-                VolumeGestureState.VOLUME_DOWN,
-                VolumeGestureState.DEFAULT,
-                VolumeGestureState.VOLUME_UP,
-            ],
-            VolumeGestureState.DEFAULT,
-            VolumeGestureState.DEFAULT
+            [0, 1], // no snapping is needed as volume change is continuous, but this will automatically clamp progress to [0, 1]
+            this._sink.volume / this._maxVolume, // current normalized volume
+            0 // can be whatever
         );
     }
 
     _gestureUpdate(_tracker: SwipeTracker, progress: number): void {
-        this._progress = Math.clamp(
-            progress,
-            VolumeGestureState.VOLUME_DOWN,
-            VolumeGestureState.VOLUME_UP
-        );
+        const volume = progress * this._maxVolume;
 
-        switch (this._volumeGestureState) {
-            case VolumeGestureState.DEFAULT:
-                if (this._progress > VolumeGestureState.DEFAULT) {
-                    this._volumeGestureState = VolumeGestureState.VOLUME_UP;
-                }
-
-                if (this._progress < VolumeGestureState.DEFAULT) {
-                    this._volumeGestureState = VolumeGestureState.VOLUME_DOWN;
-                }
-
-                break;
-            case VolumeGestureState.VOLUME_UP:
-                this._keyboard.sendKeys([Clutter.KEY_AudioRaiseVolume]);
-                this._volumeGestureState = VolumeGestureState.DEFAULT;
-                break;
-            case VolumeGestureState.VOLUME_DOWN:
-                this._keyboard.sendKeys([Clutter.KEY_AudioLowerVolume]);
-                this._volumeGestureState = VolumeGestureState.DEFAULT;
+        if (volume > 0) {
+            this._sink.change_is_muted(false);
         }
+
+        this._sink.volume = volume;
+        this._sink.push_volume();
+
+        this._show_osd(volume);
     }
 
     _gestureEnd(
         _tracker: SwipeTracker,
         duration: number,
-        progress: VolumeGestureState
-    ): void {
-        this._volumeGestureState = VolumeGestureState.DEFAULT;
-    }
+        progress: number
+    ): void {}
 }

--- a/extension/types/gnome-shell/ui/main.d.ts
+++ b/extension/types/gnome-shell/ui/main.d.ts
@@ -66,7 +66,7 @@ declare module 'resource:///org/gnome/shell/ui/main.js' {
         show(
             monitor: number,
             icon: Gio.Icon,
-            label: string,
+            label: string | null,
             percentage: number
         ): void;
         hideAll(): void;

--- a/extension/types/gnome-shell/ui/main.d.ts
+++ b/extension/types/gnome-shell/ui/main.d.ts
@@ -3,6 +3,7 @@ declare module 'resource:///org/gnome/shell/ui/main.js' {
     import Clutter from 'gi://Clutter';
     import St from 'gi://St';
     import Shell from 'gi://Shell';
+    import Gio from 'gi://Gio';
 
     import {ControlsManager} from 'resource:///org/gnome/shell/ui/overviewControls.js';
     import {SwipeTracker} from 'resource:///org/gnome/shell/ui/swipeTracker.js';
@@ -62,6 +63,12 @@ declare module 'resource:///org/gnome/shell/ui/main.js' {
     };
 
     const osdWindowManager: {
+        show(
+            monitor: number,
+            icon: Gio.Icon,
+            label: string,
+            percentage: number
+        ): void;
         hideAll(): void;
     };
 }

--- a/extension/ui/customizations.ui
+++ b/extension/ui/customizations.ui
@@ -14,7 +14,7 @@
     <object class="AdwPreferencesPage" id="customizations_page">
         <property name="title">Misc</property>
         <property name="icon-name">emblem-system-symbolic</property>
-        
+
         <!-- Customizations -->
         <child>
             <object class="AdwPreferencesGroup">
@@ -139,6 +139,45 @@
                     </object>
                 </child>
 
+                <!-- Brightness control speed -->
+                <child>
+                    <object class="AdwActionRow">
+                        <property name="title" translatable="yes">Brightness control speed</property>
+                        <property name="subtitle">Adjust the rate of change for brightness control by swipe gesture</property>
+
+                        <child>
+                            <object class="GtkScale" id="brightness-control-speed">
+                                <property name="width-request">100</property>
+                                <property name="hexpand">true</property>
+                                <property name="draw-value">no</property>
+                                <property name="adjustment">
+                                    <object class="GtkAdjustment">
+                                        <property name="lower">-3.3219280948873626</property>
+                                        <property name="upper">3.3219280948873626</property>
+                                        <property name="step-increment">0.01</property>
+                                    </object>
+                                </property>
+                                <marks>
+                                    <mark value="-1" position="bottom"></mark>
+                                    <mark value="0" position="bottom"></mark>
+                                    <mark value="1" position="bottom"></mark>
+                                </marks>
+                            </object>
+                        </child>
+
+                        <child>
+                            <object class="GtkEditableLabel" id="brightness-control-speed_display-value">
+                                <property name="valign">center</property>
+                                <property name="max_width_chars">5</property>
+                                <property name="editable">False</property>
+                                <property name="can-focus">False</property>
+                                <property name="text">1.00</property>
+                            </object>
+                        </child>
+
+                    </object>
+                </child>
+
                 <!-- Follow natural swipe -->
                 <child>
                     <object class="AdwActionRow">
@@ -166,11 +205,37 @@
                     </object>
                 </child>
 
+                <!-- Invert volume direction -->
+                <child>
+                    <object class="AdwActionRow">
+                        <property name="title" translatable="yes">Invert volume gesture direction</property>
+                        <child>
+                        <object class="GtkSwitch" id="invert-volume-gesture-direction">
+                            <property name="valign">center</property>
+                            <property name="active">False</property>
+                        </object>
+                        </child>
+                    </object>
+                </child>
+
+                <!-- Invert brightness direction -->
+                <child>
+                    <object class="AdwActionRow">
+                        <property name="title" translatable="yes">Invert brightness gesture direction</property>
+                        <child>
+                        <object class="GtkSwitch" id="invert-brightness-gesture-direction">
+                            <property name="valign">center</property>
+                            <property name="active">False</property>
+                        </object>
+                        </child>
+                    </object>
+                </child>
+
                 <!-- Enable vertical swipe for application specific gestures -->
                 <child>
                     <object class="AdwActionRow">
                         <property name="title" translatable="yes">Enable vertical swipe for app gestures</property>
-                        <property name="subtitle">[Experimental] Need to disbale 3/4-fingers vertical swipe to activate</property>
+                        <property name="subtitle">[Experimental] Need to disable 3/4-fingers vertical swipe to activate</property>
                         <child>
                             <object class="GtkSwitch" id="enable-vertical-app-gesture">
                                 <property name="valign">center</property>

--- a/extension/ui/gestures.ui
+++ b/extension/ui/gestures.ui
@@ -19,6 +19,7 @@
             <item translatable="yes">Workspace Switching</item>
             <item translatable="yes">Window Switching</item>
             <item translatable="yes">Volume Control</item>
+            <item translatable="yes">Brightness Control</item>
             <item translatable="yes">Window Manipulation</item>
         </items>
     </object>
@@ -30,6 +31,7 @@
             <item translatable="yes">Workspace Switching</item>
             <item translatable="yes">Window Switching</item>
             <item translatable="yes">Volume Control</item>
+            <item translatable="yes">Brightness Control</item>
         </items>
     </object>
 
@@ -57,7 +59,7 @@
                         <property name="model">horizontal_swipe_gestures_model</property>
                     </object>
                 </child>
-            
+
             </object>
         </child>
 
@@ -81,7 +83,7 @@
                         <property name="model">horizontal_swipe_gestures_model</property>
                     </object>
                 </child>
-            
+
             </object>
         </child>
 


### PR DESCRIPTION
Key changes in this pull request:
- Volume control is now done directly using GVC, without sending virtual key strokes
- As a result volume control is a lot smoother (almost as good as on Windows), doesn't produce popping sounds, and makes the speed setting work (fixes #17)
- Added brightness control gesture using DBus and a setting for its speed
- Added toggles for inverting brightness and volume gestures
- Fixed some typos and updated readme

I am not very familiar with typescript or writing gnome extensions, so I took some code from 2 other related extensions, which are licensed under GPL and credited in the readme.

New gestures are tested and working on ubuntu 24.04 and 25.04 (gnome 46 and 48) 