### PR TITLE
fix: swap left and right visual indicator for the forward/back gesture if reverse option is enabled

### DIFF
--- a/extension/src/forwardBack.ts
+++ b/extension/src/forwardBack.ts
@@ -173,8 +173,22 @@ export class ForwardBackGestureExtension implements ISubExtension {
         ];
         const workArea = this._getWorkArea();
 
-        if (progress > AnimationState.DEFAULT) {
-            this._animationState = AnimationState.RIGHT;
+        // Check if the focused app has the reverse flag set
+        const focusApp = this._windowTracker.focus_app as Shell.App | null;
+        const keyBind = focusApp
+            ? this._appForwardBackKeyBinds[focusApp.get_id()]
+            : null;
+        const isReversed = keyBind ? keyBind[1] : false;
+
+        const goingRight = progress > AnimationState.DEFAULT;
+        this._animationState = goingRight
+            ? AnimationState.RIGHT
+            : AnimationState.LEFT;
+
+        // When reversed, invert the arrow visual
+        const showLeftArrow = goingRight !== isReversed;
+
+        if (showLeftArrow) {
             this._arrowIconAnimation.gestureBegin(
                 'arrow1-left-symbolic.svg',
                 true
@@ -184,7 +198,6 @@ export class ForwardBackGestureExtension implements ISubExtension {
                 workArea.y + Math.round((workArea.height - height) / 2)
             );
         } else {
-            this._animationState = AnimationState.LEFT;
             this._arrowIconAnimation.gestureBegin(
                 'arrow1-right-symbolic.svg',
                 false

--- a/extension/src/volumeControl.ts
+++ b/extension/src/volumeControl.ts
@@ -151,7 +151,12 @@ export class VolumeControlGestureExtension implements ISubExtension {
         const icon = Gio.Icon.new_for_string(VolumeIcons[iconIndex]);
         const label = this._sink?.get_port().human_port ?? ''; // Recovered label logic
 
-        Main.osdWindowManager.showAll(icon, label, level, this._maxVolumeLimitRatio);
+        Main.osdWindowManager.showAll(
+            icon,
+            label,
+            level,
+            this._maxVolumeLimitRatio
+        );
     }
 
     _gestureBegin(_tracker: SwipeTracker): void {


### PR DESCRIPTION
This PR swaps the left and right circles when the inverse option is active.