### PR TITLE
feat[swipe, pinch]: Added Media & Volume Controls to 4 finger gestures 

### DIFF
--- a/extension/common/settings.ts
+++ b/extension/common/settings.ts
@@ -7,6 +7,7 @@ export enum PinchGestureType {
     OPEN_CLOSE_WINDOW = 2,
     OPEN_CLOSE_DOCUMENT = 3,
     SHOW_NOTIFICATION_LIST = 4,
+    VOLUME_CONTROL = 5,
 }
 
 export enum SwipeGestureType {
@@ -17,6 +18,7 @@ export enum SwipeGestureType {
     VOLUME_CONTROL = 4,
     BRIGHTNESS_CONTROL = 5,
     WINDOW_MANIPULATION = 6,
+    MEDIA_CONTROL = 7,
 }
 
 export enum OverviewNavigationState {

--- a/extension/extension.ts
+++ b/extension/extension.ts
@@ -21,8 +21,11 @@ import {OpenCloseWindowTabExtension} from './src/pinchGestures/openCloseWindowTa
 import {ShowNotificationListExtension} from './src/pinchGestures/showNotificationList.js';
 import {VolumeControlGestureExtension} from './src/volumeControl.js';
 import {BrightnessControlGestureExtension} from './src/brightnessControl.js';
+import {MediaControlGestureExtension} from './src/mediaControl.js';
+import {PinchVolumeControlExtension} from './src/pinchGestures/volumeControl.js';
 
 export default class TouchpadGestureCustomization extends Extension {
+
     private _extensions: ISubExtension[];
     settings?: Gio.Settings;
     private _settingChangedId = 0;
@@ -248,6 +251,15 @@ export default class TouchpadGestureCustomization extends Extension {
                 new ShowNotificationListExtension(showNotificationListFingers)
             );
 
+        // pinch to control volume
+        const pinchVolumeControlFingers = pinchToFingersMap.get(
+            PinchGestureType.VOLUME_CONTROL
+        );
+        if (pinchVolumeControlFingers?.length)
+            this._extensions.push(
+                new PinchVolumeControlExtension(pinchVolumeControlFingers)
+            );
+
         // TODO: consider having an option for 'hold and swipe gestures' that can either
         // be set to window tiling or app gesture (need to fix how to activate window tiling with
         // hold and swipe without being blocked by overview navigation)
@@ -336,6 +348,39 @@ export default class TouchpadGestureCustomization extends Extension {
             }
 
             this._extensions.push(brightnessControlGestureExtension);
+        }
+
+        /**
+         * Media Control
+         */
+
+        const verticalMediaControlFingers = verticalSwipeToFingersMap.get(
+            SwipeGestureType.MEDIA_CONTROL
+        );
+        const horizontalMediaControlFingers = horizontalSwipeToFingersMap.get(
+            SwipeGestureType.MEDIA_CONTROL
+        );
+
+        if (
+            verticalMediaControlFingers?.length ||
+            horizontalMediaControlFingers?.length
+        ) {
+            const mediaControlGestureExtension =
+                new MediaControlGestureExtension();
+
+            if (verticalMediaControlFingers?.length) {
+                mediaControlGestureExtension.setVerticalSwipeTracker(
+                    verticalMediaControlFingers
+                );
+            }
+
+            if (horizontalMediaControlFingers?.length) {
+                mediaControlGestureExtension.setHorizontalSwipeTracker(
+                    horizontalMediaControlFingers
+                );
+            }
+
+            this._extensions.push(mediaControlGestureExtension);
         }
 
         /**
@@ -475,4 +520,5 @@ export default class TouchpadGestureCustomization extends Extension {
         this._extensions.reverse().forEach(extension => extension.destroy());
         this._extensions = [];
     }
+
 }

--- a/extension/schemas/org.gnome.shell.extensions.touchpad-gesture-customization.gschema.xml
+++ b/extension/schemas/org.gnome.shell.extensions.touchpad-gesture-customization.gschema.xml
@@ -6,6 +6,7 @@
     <value value='2' nick='CLOSE_WINDOW' />
     <value value='3' nick='CLOSE_DOCUMENT' />
     <value value='4' nick='SHOW_NOTIFICATION_LIST' />
+    <value value='5' nick='VOLUME_CONTROL' />
   </enum>
   <enum id='org.gnome.shell.extensions.touchpad-gesture-customization.overview-navigation-states'>
     <value value='0' nick='CYCLIC' />
@@ -24,6 +25,7 @@
     <value value='4' nick='VOLUME_CONTROL' />
     <value value='5' nick='BRIGHTNESS_CONTROL' />
     <value value='6' nick='WINDOW_MANIPULATION' />
+    <value value='7' nick='MEDIA_CONTROL' />
   </enum>
   <enum id='org.gnome.shell.extensions.touchpad-gesture-customization.horizontal-swipe-gestures'>
     <value value='0' nick='NONE' />
@@ -32,6 +34,7 @@
     <value value='3' nick='WINDOW_SWITCHING' />
     <value value='4' nick='VOLUME_CONTROL' />
     <value value='5' nick='BRIGHTNESS_CONTROL' />
+    <value value='6' nick='MEDIA_CONTROL' />
   </enum>
   <schema id="org.gnome.shell.extensions.touchpad-gesture-customization" path="/org/gnome/shell/extensions/touchpad-gesture-customization/">
     <!-- See also: https://docs.gtk.org/glib/gvariant-format-strings.html -->

--- a/extension/src/mediaControl.ts
+++ b/extension/src/mediaControl.ts
@@ -1,0 +1,102 @@
+import Clutter from 'gi://Clutter';
+import Shell from 'gi://Shell';
+import {TouchpadSwipeGesture} from './swipeTracker.js';
+import {getVirtualKeyboard} from './utils/keyboard.js';
+
+export class MediaControlGestureExtension implements ISubExtension {
+
+    private _verticalTouchpadSwipeTracker?: typeof TouchpadSwipeGesture.prototype;
+    private _horizontalTouchpadSwipeTracker?: typeof TouchpadSwipeGesture.prototype;
+    private _verticalConnectHandlers?: number[];
+    private _horizontalConnectHandlers?: number[];
+    private _verticalDelta = 0;
+    private _horizontalDelta = 0;
+    private _threshold = 50; // Threshold for swipe to trigger action
+
+    apply() {
+        // Nothing special to apply on startup
+    }
+
+    destroy(): void {
+        this._verticalConnectHandlers?.forEach(handle =>
+            this._verticalTouchpadSwipeTracker?.disconnect(handle)
+        );
+        this._verticalConnectHandlers = undefined;
+        this._verticalTouchpadSwipeTracker?.destroy();
+
+        this._horizontalConnectHandlers?.forEach(handle =>
+            this._horizontalTouchpadSwipeTracker?.disconnect(handle)
+        );
+        this._horizontalConnectHandlers = undefined;
+        this._horizontalTouchpadSwipeTracker?.destroy();
+    }
+
+    setVerticalSwipeTracker(nfingers: number[]) {
+        this._verticalTouchpadSwipeTracker = new TouchpadSwipeGesture(
+            nfingers,
+            Shell.ActionMode.NORMAL | Shell.ActionMode.OVERVIEW,
+            Clutter.Orientation.VERTICAL,
+            true // followNaturalScroll
+        );
+
+        this._verticalConnectHandlers = [
+            this._verticalTouchpadSwipeTracker.connect('begin', () => {
+                this._verticalDelta = 0;
+            }),
+            this._verticalTouchpadSwipeTracker.connect(
+                'update',
+                (_gesture, _time, delta) => {
+                    this._verticalDelta += delta;
+                }
+            ),
+            this._verticalTouchpadSwipeTracker.connect('end', () => {
+                if (this._verticalDelta > this._threshold) {
+                    // Swipe Down (positive delta) -> Prev Track (reversed from original)
+                    getVirtualKeyboard().sendKeys([Clutter.KEY_AudioPrev]);
+                } else if (this._verticalDelta < -this._threshold) {
+                    // Swipe Up (negative delta) -> Next Track (reversed from original)
+                    getVirtualKeyboard().sendKeys([Clutter.KEY_AudioNext]);
+                }
+            }),
+            this._verticalTouchpadSwipeTracker.connect('hold', () => {
+                // Hold -> Play/Pause
+                getVirtualKeyboard().sendKeys([Clutter.KEY_AudioPlay]);
+            }),
+        ];
+    }
+
+    setHorizontalSwipeTracker(nfingers: number[]) {
+        this._horizontalTouchpadSwipeTracker = new TouchpadSwipeGesture(
+            nfingers,
+            Shell.ActionMode.NORMAL | Shell.ActionMode.OVERVIEW,
+            Clutter.Orientation.HORIZONTAL,
+            true // followNaturalScroll
+        );
+
+        this._horizontalConnectHandlers = [
+            this._horizontalTouchpadSwipeTracker.connect('begin', () => {
+                this._horizontalDelta = 0;
+            }),
+            this._horizontalTouchpadSwipeTracker.connect(
+                'update',
+                (_gesture, _time, delta) => {
+                    this._horizontalDelta += delta;
+                }
+            ),
+            this._horizontalTouchpadSwipeTracker.connect('end', () => {
+                if (this._horizontalDelta > this._threshold) {
+                    // Swipe Right -> Prev Track
+                    getVirtualKeyboard().sendKeys([Clutter.KEY_AudioPrev]);
+                } else if (this._horizontalDelta < -this._threshold) {
+                    // Swipe Left -> Next Track
+                    getVirtualKeyboard().sendKeys([Clutter.KEY_AudioNext]);
+                }
+            }),
+            this._horizontalTouchpadSwipeTracker.connect('hold', () => {
+                // Hold -> Play/Pause
+                getVirtualKeyboard().sendKeys([Clutter.KEY_AudioPlay]);
+            }),
+        ];
+    }
+
+}

--- a/extension/src/pinchGestures/volumeControl.ts
+++ b/extension/src/pinchGestures/volumeControl.ts
@@ -1,0 +1,155 @@
+import Clutter from 'gi://Clutter';
+import Shell from 'gi://Shell';
+import Gio from 'gi://Gio';
+import Gvc from 'gi://Gvc';
+import * as Main from 'resource:///org/gnome/shell/ui/main.js';
+import * as Volume from 'resource:///org/gnome/shell/ui/status/volume.js';
+import {TouchpadPinchGesture} from './pinchTracker.js';
+
+const VolumeIcons = [
+    'audio-volume-muted-symbolic',
+    'audio-volume-low-symbolic',
+    'audio-volume-medium-symbolic',
+    'audio-volume-high-symbolic',
+    'audio-volume-overamplified-symbolic',
+];
+
+export class PinchVolumeControlExtension implements ISubExtension {
+
+    private _pinchTracker?: typeof TouchpadPinchGesture.prototype;
+    private _controller?: Gvc.MixerControl;
+    private _sink?: Gvc.MixerStream;
+    private _maxVolume!: number;
+    private _sinkChangeBinding!: number;
+    private _lastOsdShowTimestamp: number = 0;
+    private _audioSettings!: Gio.Settings;
+    private _maxVolumeLimitRatio: number = 1.0;
+    private _connectHandlers?: number[];
+
+    constructor(private _nfingers: number[]) {}
+
+    apply() {
+        this._controller = Volume.getMixerControl();
+        this._maxVolume = this._controller.get_vol_max_norm();
+        this._audioSettings = new Gio.Settings({
+            schema_id: 'org.gnome.desktop.sound',
+        });
+        this._sink = this._controller.get_default_sink();
+        this._sinkChangeBinding = this._controller.connect(
+            'default-sink-changed',
+            this._handleSinkChange.bind(this)
+        );
+
+        this._pinchTracker = new TouchpadPinchGesture({
+            nfingers: this._nfingers,
+            allowedModes: Shell.ActionMode.NORMAL | Shell.ActionMode.OVERVIEW,
+        });
+
+        this._connectHandlers = [
+            this._pinchTracker.connect('begin', this._gestureBegin.bind(this)),
+            this._pinchTracker.connect(
+                'update',
+                this._gestureUpdate.bind(this)
+            ),
+            this._pinchTracker.connect('end', this._gestureEnd.bind(this)),
+        ];
+    }
+
+    destroy(): void {
+        this._controller?.disconnect(this._sinkChangeBinding);
+        delete this._controller;
+        delete this._sink;
+
+        // @ts-expect-error: audioSettings is a private property that needs cleanup
+        delete this._audioSettings; // Cleanup settings object
+
+        this._connectHandlers?.forEach(handle =>
+            this._pinchTracker?.disconnect(handle)
+        );
+        this._connectHandlers = undefined;
+        this._pinchTracker?.destroy();
+    }
+
+    _handleSinkChange(controller: Gvc.MixerControl, id: number) {
+        this._sink = controller.lookup_stream_id(id);
+    }
+
+    _showOsd(volume: number) {
+        const nowTimestamp = Date.now();
+
+        if (nowTimestamp - this._lastOsdShowTimestamp < 1000 / 30) {
+            return;
+        }
+
+        this._lastOsdShowTimestamp = nowTimestamp;
+
+        const level = volume / this._maxVolume;
+        let iconIndex: number;
+
+        if (volume === 0) {
+            iconIndex = 0;
+        } else if (level > 1.0) {
+            iconIndex = 4;
+        } else {
+            iconIndex = Math.clamp(Math.floor(3 * level + 1), 1, 3);
+        }
+
+        const icon = Gio.Icon.new_for_string(VolumeIcons[iconIndex]);
+        const label = this._sink?.get_port().human_port ?? '';
+
+        Main.osdWindowManager.showAll(
+            icon,
+            label,
+            level,
+            this._maxVolumeLimitRatio
+        );
+    }
+
+    _gestureBegin(): void {
+        if (
+            this._sink === undefined ||
+            this._controller === undefined ||
+            this._pinchTracker === undefined
+        ) {
+            return;
+        }
+
+        const isOverampEnabled = this._audioSettings.get_boolean(
+            'allow-volume-above-100-percent'
+        );
+
+        this._maxVolumeLimitRatio = isOverampEnabled
+            ? this._controller.get_vol_max_amplified() / this._maxVolume
+            : 1.0;
+
+        this._pinchTracker.confirmPinch(
+            1,
+            [0, this._maxVolumeLimitRatio],
+            this._sink.volume / this._maxVolume
+        );
+    }
+
+    _gestureUpdate(_tracker: unknown, progress: number): void {
+        if (this._sink === undefined) {
+            return;
+        }
+
+        const volume = progress * this._maxVolume;
+
+        if (volume > 0) {
+            this._sink.change_is_muted(false);
+        }
+
+        this._sink.volume = volume;
+        this._sink.push_volume();
+
+        this._showOsd(volume);
+    }
+
+    _gestureEnd(
+        _tracker: unknown,
+        _duration: number,
+        _endProgress: number
+    ): void {}
+
+}

--- a/extension/src/swipeTracker.ts
+++ b/extension/src/swipeTracker.ts
@@ -51,9 +51,11 @@ export const TouchpadSwipeGesture = GObject.registerClass(
                 ],
             },
             end: {param_types: [GObject.TYPE_UINT, GObject.TYPE_DOUBLE]},
+            hold: {param_types: [GObject.TYPE_UINT]},
         },
     },
     class TouchpadSwipeGesture extends GObject.Object {
+
         private _nfingers: number[];
         private _allowedModes: Shell.ActionMode;
         orientation: Clutter.Orientation;
@@ -235,17 +237,28 @@ export const TouchpadSwipeGesture = GObject.registerClass(
         }
 
         private _handleHoldEvent(event: CustomEventType) {
+            if (
+                !this._nfingers.includes(
+                    event.get_touchpad_gesture_finger_count()
+                )
+            ) {
+                return;
+            }
+
             switch (event.get_gesture_phase()) {
                 case Clutter.TouchpadGesturePhase.BEGIN:
                     this._holdGestureCancelTime = 0;
                     this._holdGestureBeginTime = event.get_time();
+                    this.emit('hold', event.get_time());
                     break;
                 case Clutter.TouchpadGesturePhase.CANCEL:
                     this._holdGestureCancelTime = event.get_time();
                     break;
+
                 case Clutter.TouchpadGesturePhase.END:
                     this._holdGestureBeginTime = 0;
                     this._holdGestureCancelTime = 0;
+                    break;
             }
         }
 
@@ -272,7 +285,8 @@ export const TouchpadSwipeGesture = GObject.registerClass(
                 this._stageCaptureEvent = null;
             }
         }
-    }
+    
+}
 );
 
 export function createSwipeTracker(

--- a/extension/ui/gestures.ui
+++ b/extension/ui/gestures.ui
@@ -10,6 +10,7 @@
             <item translatable="yes">Open/Close Window</item>
             <item translatable="yes">Open/Close Tab (Ctrl + W)</item>
             <item translatable="yes">Show notification list</item>
+            <item translatable="yes">Volume Control</item>
         </items>
     </object>
 
@@ -22,6 +23,7 @@
             <item translatable="yes">Volume Control</item>
             <item translatable="yes">Brightness Control</item>
             <item translatable="yes">Window Manipulation</item>
+            <item translatable="yes">Media Control</item>
         </items>
     </object>
 
@@ -33,6 +35,7 @@
             <item translatable="yes">Window Switching</item>
             <item translatable="yes">Volume Control</item>
             <item translatable="yes">Brightness Control</item>
+            <item translatable="yes">Media Control</item>
         </items>
     </object>
 


### PR DESCRIPTION
### Summary
Added Media & Volume Control options to 4 finger gestures. 
- Media Controls: Implements Play/Pause by resting 4 fingers on the touchpad (via TOUCHPAD_HOLD), and next/prev track via 4 finger swipes
- Volume Controls: 4 finger pinch adjusts volume and displays native OSD.

### Testing
Tested on: GNOME Shell 50.1 (Ubuntu 26.04 LTS) under Wayland
Tested End 2 End manually, by running locally and testing. Works well.


### Checklist
- [x] Lint passes
- [x] Tested locally
- [x] Updated metadata.json if needed (Not needed, Not updated)