### PR TITLE
fix(alt-tab): improve window switching across workspaces

### DIFF
--- a/extension/common/settings.ts
+++ b/extension/common/settings.ts
@@ -42,6 +42,7 @@ export enum ForwardBackKeyBinds {
 export type BooleanSettingsKeys =
     | 'allow-minimize-window'
     | 'allow-fullscreen-window'
+    | 'alttab-all-workspaces'
     | 'follow-natural-scroll'
     | 'invert-volume-gesture-direction'
     | 'invert-brightness-gesture-direction'

--- a/extension/constants.ts
+++ b/extension/constants.ts
@@ -36,6 +36,7 @@ export const OverviewControlsState = {
 export const ExtSettings = {
     ALLOW_MINIMIZE_WINDOW: false,
     ALLOW_FULLSCREEN_WINDOW: true,
+    ALTTAB_ALL_WORKSPACES: false,
     FOLLOW_NATURAL_SCROLL: true,
     APP_GESTURES: false,
     DEFAULT_OVERVIEW_GESTURE_DIRECTION: true,

--- a/extension/extension.ts
+++ b/extension/extension.ts
@@ -436,6 +436,8 @@ export default class TouchpadGestureCustomization extends Extension {
                 this.settings.get_boolean('allow-minimize-window');
             Constants.ExtSettings.ALLOW_FULLSCREEN_WINDOW =
                 this.settings.get_boolean('allow-fullscreen-window');
+            Constants.ExtSettings.ALTTAB_ALL_WORKSPACES =
+                this.settings.get_boolean('alttab-all-workspaces');
             Constants.ExtSettings.FOLLOW_NATURAL_SCROLL =
                 this.settings.get_boolean('follow-natural-scroll');
             Constants.ExtSettings.DEFAULT_OVERVIEW_GESTURE_DIRECTION =

--- a/extension/prefs/pref.ts
+++ b/extension/prefs/pref.ts
@@ -154,6 +154,7 @@ function bindPrefsSettings(builder: GtkBuilder, settings: Gio.Settings) {
 
     bind_boolean_value('allow-minimize-window', settings, builder);
     bind_boolean_value('allow-fullscreen-window', settings, builder);
+    bind_boolean_value('alttab-all-workspaces', settings, builder);
 
     bind_combo_box('vertical-swipe-3-fingers-gesture', settings, builder);
     bind_combo_box('horizontal-swipe-3-fingers-gesture', settings, builder);

--- a/extension/schemas/org.gnome.shell.extensions.touchpad-gesture-customization.gschema.xml
+++ b/extension/schemas/org.gnome.shell.extensions.touchpad-gesture-customization.gschema.xml
@@ -50,6 +50,10 @@
     <key name="alttab-delay" type="i">
       <default>150</default>
     </key>
+    <key name="alttab-all-workspaces" type="b">
+      <default>false</default>
+      <description>If true, window switcher shows windows across all workspaces</description>
+    </key>
     <key name="hold-swipe-delay-duration" type="i">
       <default>10</default>
     </key>

--- a/extension/src/altTab.ts
+++ b/extension/src/altTab.ts
@@ -207,6 +207,13 @@ export default class AltTabGestureExtension implements ISubExtension {
         this._progress = 0;
 
         if (this._extState === AltTabExtState.DEFAULT) {
+            if (ExtSettings.ALTTAB_ALL_WORKSPACES) {
+                const windowSwitcherSettings = new Gio.Settings({
+                    schema_id: 'org.gnome.shell.window-switcher',
+                });
+                windowSwitcherSettings.set_boolean('current-workspace-only', false);
+            }
+
             this._switcher = new WindowSwitcherPopup();
             this._switcher._switcherList.add_style_class_name(
                 'gie-alttab-quick-transition'
@@ -298,8 +305,14 @@ export default class AltTabGestureExtension implements ISubExtension {
     _gestureEnd(): void {
         if (this._switcher) {
             const win =
-                this._switcher._items[this._switcher._selectedIndex].window;
-            Main.activateWindow(win);
+                this._switcher._items[this._switcher._selectedIndex]?.window;
+            if (win) {
+                if (typeof (win as any).activate === 'function') {
+                    (win as any).activate(global.get_current_time());
+                } else {
+                    Main.activateWindow(win);
+                }
+            }
             this._switcher.destroy();
             this._switcher = undefined;
         }

--- a/extension/ui/customizations.ui
+++ b/extension/ui/customizations.ui
@@ -287,6 +287,19 @@
                     </object>
                 </child>
 
+                <!-- Switch windows across all workspaces -->
+                <child>
+                    <object class="AdwActionRow">
+                        <property name="title" translatable="yes">Switch windows across all workspaces</property>
+                        <property name="subtitle">Show windows from all workspaces in the Alt+Tab switcher</property>
+                        <child>
+                            <object class="GtkSwitch" id="alttab-all-workspaces">
+                                <property name="valign">center</property>
+                            </object>
+                        </child>
+                    </object>
+                </child>
+
                 <!-- Window switcher popup delay (ms) -->
                 <child>
                     <object class="AdwActionRow">


### PR DESCRIPTION
### Summary
This PR adds a convenient preference toggle in the extension settings window under the **AltTab / Window Switching** section. Users can now easily choose whether the gesture switches between windows in the **Current Workspace Only** or **Across All Workspaces** directly from the UI without needing terminal commands or Dconf Editor.

### Coded with AI
I`m testing a pipeline with agentic-coding, I`m review and testing this mods, but here is my warning.

### Testing
Opened Extension Preferences -> AltTab tab.
Toggled “Switch windows across all workspaces”.
Confirmed via gsettings get org.gnome.shell.window-switcher current-workspace-only that the setting updates accordingly (false when enabled).
Verified that performing the 3-finger swipe gesture immediately reflects all open windows across workspaces.
Tested  with gnome 50 locally