### PR TITLE
fix(alt-tab): keep unredirect inhibited while the switcher is up

### DIFF
--- a/extension/src/altTab.ts
+++ b/extension/src/altTab.ts
@@ -48,6 +48,7 @@ export default class AltTabGestureExtension implements ISubExtension {
     private _extState = AltTabExtState.DISABLED;
     private _progress = 0;
     private _altTabTimeoutId = 0;
+    private _unredirectInhibited = false;
 
     constructor() {
         this._adjustment = new St.Adjustment({
@@ -182,6 +183,29 @@ export default class AltTabGestureExtension implements ISubExtension {
             this._switcher.destroy();
             this._switcher = undefined;
         }
+
+        this._uninhibitUnredirect();
+    }
+
+    /**
+     * Main.pushModal() inhibits unredirect for us, but we pop the modal right
+     * away so that the gesture keeps working, and Main.popModal() re-enables
+     * it. Without an inhibit of our own, mutter direct-scans out a window whose
+     * paint box exactly covers the monitor (fullscreen, or maximized while the
+     * panel is hidden) and the switcher is never composited in.
+     */
+    private _inhibitUnredirect() {
+        if (this._unredirectInhibited) return;
+
+        global.compositor.disable_unredirect();
+        this._unredirectInhibited = true;
+    }
+
+    private _uninhibitUnredirect() {
+        if (!this._unredirectInhibited) return;
+
+        global.compositor.enable_unredirect();
+        this._unredirectInhibited = false;
     }
 
     _onUpdateAdjustmentValue(): void {
@@ -229,6 +253,7 @@ export default class AltTabGestureExtension implements ISubExtension {
             if (nelement > 0) {
                 this._switcher.show(false, 'switch-windows', 0);
                 this._switcher._popModal();
+                this._inhibitUnredirect();
 
                 if (this._switcher._initialDelayTimeoutId) {
                     GLib.source_remove(this._switcher._initialDelayTimeoutId);
@@ -308,6 +333,8 @@ export default class AltTabGestureExtension implements ISubExtension {
     }
 
     private _reset() {
+        this._uninhibitUnredirect();
+
         if (this._extState > AltTabExtState.DEFAULT) {
             this._extState = AltTabExtState.DEFAULT;
 


### PR DESCRIPTION
### Summary

The window switcher popup never appears when the focused window's paint box exactly covers the monitor — fullscreen, or maximized while an extension hides the panel. This keeps unredirect inhibited for the lifetime of the switcher so mutter composites the popup instead of direct-scanning out the window underneath it.

### Related issue

Fixes #54

### Root cause

`SwitcherPopup.show()` takes a modal, and `Main.pushModal()` calls `global.compositor.disable_unredirect()`. We pop that modal immediately in `_gestureBegin()` so the gesture keeps receiving events — but `Main.popModal()` then calls `enable_unredirect()`:

```js
// gnome-shell/js/ui/main.js
export function popModal(grab) {
    ...
    if (modalCount > 0)
        return;

    layoutManager.modalEnded();
    global.compositor.enable_unredirect();   // <-- undoes the inhibit show() gave us
```

Mutter's `find_scanout_candidate()` then has nothing stopping it:

```c
/* mutter/src/compositor/meta-compositor-view-native.c */
if (meta_compositor_is_unredirect_inhibited (compositor))
  {
    meta_topic (META_DEBUG_RENDER,
                "No direct scanout candidate: unredirect inhibited");
    return FALSE;
  }
```

…and the window's buffer goes straight to the display, so the popup the shell drew above it is never composited in. The second condition in that function — the top window actor's paint box matching the stage view rect exactly — is why this only reproduces on fullscreen/full-monitor-maximized windows, and why a visible panel masks the bug (it shrinks the maximized window's box so it no longer matches).

Alt+Tab is unaffected because it holds its modal for the whole duration, which is exactly what the issue reporter observed.

### The fix

Take our own inhibit right after `_popModal()` gives the original one back, and release it in `_reset()` — which covers both `_gestureEnd()` and the popup's `destroy` handler — and in `destroy()` for teardown mid-gesture. The `_unredirectInhibited` flag keeps mutter's inhibit counter balanced no matter which path ends the gesture.

### Testing

- GNOME Shell 48.7, Debian 13, Wayland
- 3-finger horizontal swipe assigned to Window Switching, `alttab-delay` 0
- Reproduced with dash-to-panel intellihide on (`intellihide-behaviour: FOCUSED_WINDOWS`), which lets a maximized window cover the full monitor:
  - **before** — maximized window focused: no popup, though the switch itself still happened; un-maximized: popup fine
  - **after** — popup appears immediately in both cases
- Also verified against a true fullscreen window, which hits the same scanout path
- Ran the gesture repeatedly plus disable/enable cycles mid-gesture; no leaked inhibit (chrome, OSD and the overview all still behave) and no errors in `journalctl /usr/bin/gnome-shell -f`

Patch was developed and tested as the transpiled JS on GNOME 48, then ported to `extension/src/altTab.ts` here; the rebuilt output is identical to what was tested.

### Checklist

- [x] Lint passes — `eslint extension` reports the same 2 pre-existing `padded-blocks` errors in this file as `main`, nothing new
- [x] `tsc --noEmit` clean, `prettier --check` clean
- [x] Tested locally
- [x] Updated metadata.json if needed — not needed, no API compatibility change
