### PR TITLE
feat[swipe]: add invert direction setting for media control gestures

### DIFF
--- a/extension/common/settings.ts
+++ b/extension/common/settings.ts
@@ -57,6 +57,7 @@ export type BooleanSettingsKeys =
     | 'follow-natural-scroll'
     | 'invert-volume-gesture-direction'
     | 'invert-brightness-gesture-direction'
+    | 'invert-media-gesture-direction'
     | 'enable-forward-back-gesture'
     | 'default-overview-gesture-direction'
     | 'enable-vertical-app-gesture';

--- a/extension/constants.ts
+++ b/extension/constants.ts
@@ -41,6 +41,7 @@ export const ExtSettings = {
     DEFAULT_OVERVIEW_GESTURE_DIRECTION: true,
     INVERT_VOLUME_DIRECTION: false,
     INVERT_BRIGHTNESS_DIRECTION: false,
+    INVERT_MEDIA_DIRECTION: false,
 };
 
 export const RELOAD_DELAY = 150; // reload extension delay in ms

--- a/extension/extension.ts
+++ b/extension/extension.ts
@@ -501,6 +501,8 @@ export default class TouchpadGestureCustomization extends Extension {
                 this.settings.get_boolean(
                     'invert-brightness-gesture-direction'
                 );
+            Constants.ExtSettings.INVERT_MEDIA_DIRECTION =
+                this.settings.get_boolean('invert-media-gesture-direction');
             Constants.ExtSettings.APP_GESTURES = this.settings.get_boolean(
                 'enable-forward-back-gesture'
             );

--- a/extension/prefs/pref.ts
+++ b/extension/prefs/pref.ts
@@ -150,6 +150,7 @@ function bindPrefsSettings(builder: GtkBuilder, settings: Gio.Settings) {
         settings,
         builder
     );
+    bind_boolean_value('invert-media-gesture-direction', settings, builder);
     bind_boolean_value('enable-vertical-app-gesture', settings, builder);
 
     bind_boolean_value('allow-minimize-window', settings, builder);

--- a/extension/schemas/org.gnome.shell.extensions.touchpad-gesture-customization.gschema.xml
+++ b/extension/schemas/org.gnome.shell.extensions.touchpad-gesture-customization.gschema.xml
@@ -80,6 +80,12 @@
       <default>true</default>
       <description>Invert brightness control gesture direction</description>
     </key>
+    <key name='invert-media-gesture-direction' type='b'>
+      <!-- Defaults to false to preserve the previously hardcoded
+           followNaturalScroll=true behaviour for existing users. -->
+      <default>false</default>
+      <description>Invert media control gesture direction</description>
+    </key>
     <key name='enable-forward-back-gesture' type='b'>
       <default>false</default>
       <description>Enable forward/back keybinding gesture</description>

--- a/extension/src/mediaControl.ts
+++ b/extension/src/mediaControl.ts
@@ -2,6 +2,7 @@ import Clutter from 'gi://Clutter';
 import Shell from 'gi://Shell';
 import {TouchpadSwipeGesture} from './swipeTracker.js';
 import {getVirtualKeyboard} from './utils/keyboard.js';
+import {ExtSettings} from '../constants.js';
 
 export class MediaControlGestureExtension implements ISubExtension {
     private _verticalTouchpadSwipeTracker?: typeof TouchpadSwipeGesture.prototype;
@@ -35,7 +36,7 @@ export class MediaControlGestureExtension implements ISubExtension {
             nfingers,
             Shell.ActionMode.NORMAL | Shell.ActionMode.OVERVIEW,
             Clutter.Orientation.VERTICAL,
-            true // followNaturalScroll
+            !ExtSettings.INVERT_MEDIA_DIRECTION // followNaturalScroll
         );
 
         this._verticalConnectHandlers = [
@@ -69,7 +70,7 @@ export class MediaControlGestureExtension implements ISubExtension {
             nfingers,
             Shell.ActionMode.NORMAL | Shell.ActionMode.OVERVIEW,
             Clutter.Orientation.HORIZONTAL,
-            true // followNaturalScroll
+            !ExtSettings.INVERT_MEDIA_DIRECTION // followNaturalScroll
         );
 
         this._horizontalConnectHandlers = [

--- a/extension/ui/customizations.ui
+++ b/extension/ui/customizations.ui
@@ -229,6 +229,19 @@
                     </object>
                 </child>
 
+                <!-- Invert media direction -->
+                <child>
+                    <object class="AdwActionRow">
+                        <property name="title" translatable="yes">Invert media gesture direction</property>
+                        <child>
+                        <object class="GtkSwitch" id="invert-media-gesture-direction">
+                            <property name="valign">center</property>
+                            <property name="active">False</property>
+                        </object>
+                        </child>
+                    </object>
+                </child>
+
                 <!-- Enable vertical swipe for application specific gestures -->
                 <child>
                     <object class="AdwActionRow">


### PR DESCRIPTION
Media control was the only swipe gesture without a direction toggle; volume and brightness both expose one. This adds the equivalent `invert-media-gesture-direction` setting, wired the same way.

`MediaControlGestureExtension` instantiates `TouchpadSwipeGesture` directly rather than going through `createSwipeTracker` (it needs the `hold` signal for play/pause, which the wrapper does not forward). The direction mechanism is identical either way: `createSwipeTracker` forwards `followNaturalScroll` straight into the same constructor argument, and the negation happens in one place, `TouchpadSwipeGesture._handleEvent`. So the new setting behaves consistently with its volume/brightness siblings.

Defaults to `false` to preserve the previously hardcoded `followNaturalScroll=true` behaviour, so existing users see no change on upgrade.

### Summary
Adds invert-media-gesture-direction, matching the existing invert-volume-/invert-brightness- settings. Media control was the only swipe gesture without a direction toggle.

### Related issue
N/A

### Testing
GNOME 50.4, Wayland, Fedora 44, extension built from source, `npm install` + `npm run update`

1. Swipe left (fingers go from right to left), observe `previous` being triggered
2. Flip the "Invert media gesture direction" switch in `Settings -> Misc`
3. Swipe left (fingers go from right to left), observe `next` being triggered

### Checklist
- [x] Lint passes - 65 errors reported, none from introduced changes
- [x] Tested locally
- [x] Updated metadata.json if needed - N/A
- [x] `tsc --noEmit` reports no type errors
- [x] `prettier --check` reports "All matched files use Prettier code style!"