### PR TITLE
docs: document media control hold gesture and swipe sensitivity

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ gnome-extensions enable touchpad-gesture-customization@coooolapps.com
 | Snap/half-tile a window  | Part of Window Manipulation, snap window to <br>either half of screen | 3/4/both | Vertical (\*) |
 | Volume Control           | Increase/decrease system volume              | 3/4/both | Vertical/Horizontal |
 | Brightness Control       | Increase/decrease system brightness          | 3/4/both | Vertical/Horizontal |
-| Media Control            | Play next/previous media                     | 3/4/both | Vertical/Horizontal |
+| Media Control            | Play next/previous media, hold to play/pause | 3/4/both | Vertical/Horizontal |
 
 | Pinch Gesture Actions   | Description                                     | Fingers |
 | :---------------------- | :---------------------------------------------- | :------ |
@@ -86,6 +86,12 @@ gnome-extensions enable touchpad-gesture-customization@coooolapps.com
 
 - For horizontal gestures, application gesture only works if 3/4-fingers horizontal swipe is set to **Window Switching**
 - Application gesture also supports vertical swipe but is still experimental and requires users to turn off other actions for 3/4-fingers vertical swipe (i.e. set the action to None).
+
+#### Media Control Notes
+
+- In addition to swiping, resting 3/4 fingers on the touchpad (a *hold* gesture) toggles play/pause. The action fires as soon as the hold is registered, so you get immediate feedback that the gesture was recognised. Note that libinput only reports a hold once the fingers have been still for a short moment, so a quick tap does not trigger it.
+- Media Control sends the standard media keys (`XF86AudioNext` / `XF86AudioPrev` / `XF86AudioPlay`), so it applies to whichever player GNOME currently considers active, exactly as pressing the media keys on a keyboard would. It is not tied to any specific application.
+- How far you need to swipe before a track changes scales with the **Touchpad swipe speed** setting: raising it makes media swipes trigger with a shorter movement.
 
 #### Notes
 


### PR DESCRIPTION
The hold-to-play/pause action has been available since media control was added but was not mentioned anywhere in the README, so it was effectively undiscoverable.

Also documents two things that come up when using the gesture:

- Media Control sends the standard media keys rather than talking to a specific player, so it follows GNOME's active player like the keyboard media keys do.
- The swipe distance needed to change track scales with the existing "Touchpad swipe speed" setting, since the accumulated delta is already multiplied by TouchpadConstants.SWIPE_MULTIPLIER. No new setting is needed to tune it, it just was not written down.

### Summary
Updated `README.md`

### Related issue
N/A

### Testing
N/A

### Checklist
- [x] Lint passes - N/A
- [x] Tested locally - N/A
- [x] Updated metadata.json if needed - N/A