### PR TITLE
feat: Keyboard backlight pinch gesture & some minor fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ This extension modifies and extends existing touchpad gestures on GNOME using Wa
 
 ### Manually
 
-**Note**: Please choose correct branch for your corresponding version of GNOME first. 
+**Note**: Please choose correct branch for your corresponding version of GNOME first.
 
 1. Install extension
 
@@ -54,13 +54,14 @@ gnome-extensions enable touchpad-gesture-customization@coooolapps.com
 | Brightness Control       | Increase/decrease system brightness          | 3/4/both | Vertical/Horizontal |
 | Media Control            | Play next/previous media, hold to play/pause | 3/4/both | Vertical/Horizontal |
 
-| Pinch Gesture Actions   | Description                                     | Fingers |
-| :---------------------- | :---------------------------------------------- | :------ |
-| Show Desktop (\*)       | Hide all application (i.e. windows), pinch out  | 3/4     |
-| Open/Close Window       | Open/Close an application, like clicking on "x" | 3/4     |
-| Open/Close Tab/Document | Open/Close a tab in application that uses tabs  | 3/4     |
-| Show Notification List  | Show GNOME notification                         | 3/4     |
-| Volume Control          | Increase/decrease system volume                 | 3/4     |
+| Pinch Gesture Actions      | Description                                     | Fingers |
+| :----------------------    | :---------------------------------------------- | :------ |
+| Show Desktop (\*)          | Hide all application (i.e. windows), pinch out  | 3/4     |
+| Open/Close Window          | Open/Close an application, like clicking on "x" | 3/4     |
+| Open/Close Tab/Document    | Open/Close a tab in application that uses tabs  | 3/4     |
+| Show Notification List     | Show GNOME notification                         | 3/4     |
+| Volume Control             | Increase/decrease system volume                 | 3/4     |
+| Keyboard Backlight Control | Increase/decrease keyboard backlight            | 3/4     |
 
 | Application Gestures Actions (\*) | Description                                      |
 | :-------------------------------- | :----------------------------------------------- |
@@ -92,6 +93,9 @@ gnome-extensions enable touchpad-gesture-customization@coooolapps.com
 - In addition to swiping, resting 3/4 fingers on the touchpad (a *hold* gesture) toggles play/pause. The action fires as soon as the hold is registered, so you get immediate feedback that the gesture was recognised. Note that libinput only reports a hold once the fingers have been still for a short moment, so a quick tap does not trigger it.
 - Media Control sends the standard media keys (`XF86AudioNext` / `XF86AudioPrev` / `XF86AudioPlay`), so it applies to whichever player GNOME currently considers active, exactly as pressing the media keys on a keyboard would. It is not tied to any specific application.
 - How far you need to swipe before a track changes scales with the **Touchpad swipe speed** setting: raising it makes media swipes trigger with a shorter movement.
+
+#### Keyboard Backlight Notes
+- This will only work if you have a Keyboard Backlight tile in Gnome quick settings.
 
 #### Notes
 

--- a/extension/common/settings.ts
+++ b/extension/common/settings.ts
@@ -8,6 +8,7 @@ export enum PinchGestureType {
     OPEN_CLOSE_DOCUMENT = 3,
     SHOW_NOTIFICATION_LIST = 4,
     VOLUME_CONTROL = 5,
+    KEYBOARD_BACKLIGHT_CONTROL = 6,
 }
 
 export enum VerticalSwipeGestureType {

--- a/extension/constants.ts
+++ b/extension/constants.ts
@@ -47,3 +47,4 @@ export const ExtSettings = {
 
 export const RELOAD_DELAY = 150; // reload extension delay in ms
 export const WIDGET_SHOWING_DURATION = 100; // animation duration for showing widget
+export const OSD_FRAMETIME_CAP_MS = 1000 / 30; // frametime lower limit for osd updates

--- a/extension/extension.ts
+++ b/extension/extension.ts
@@ -24,6 +24,7 @@ import {VolumeControlGestureExtension} from './src/volumeControl.js';
 import {BrightnessControlGestureExtension} from './src/brightnessControl.js';
 import {MediaControlGestureExtension} from './src/mediaControl.js';
 import {PinchVolumeControlExtension} from './src/pinchGestures/volumeControl.js';
+import {PinchKeyboardBacklightControlExtension} from './src/pinchGestures/keyboardBacklightControl.js';
 
 export default class TouchpadGestureCustomization extends Extension {
     private _extensions: ISubExtension[];
@@ -262,6 +263,17 @@ export default class TouchpadGestureCustomization extends Extension {
         if (pinchVolumeControlFingers?.length)
             this._extensions.push(
                 new PinchVolumeControlExtension(pinchVolumeControlFingers)
+            );
+
+        // pinch to control keyboard backlight
+        const pinchKeyboardControlFingers = pinchToFingersMap.get(
+            PinchGestureType.KEYBOARD_BACKLIGHT_CONTROL
+        );
+        if (pinchKeyboardControlFingers?.length)
+            this._extensions.push(
+                new PinchKeyboardBacklightControlExtension(
+                    pinchKeyboardControlFingers
+                )
             );
 
         // TODO: consider having an option for 'hold and swipe gestures' that can either

--- a/extension/schemas/org.gnome.shell.extensions.touchpad-gesture-customization.gschema.xml
+++ b/extension/schemas/org.gnome.shell.extensions.touchpad-gesture-customization.gschema.xml
@@ -7,6 +7,7 @@
     <value value='3' nick='CLOSE_DOCUMENT' />
     <value value='4' nick='SHOW_NOTIFICATION_LIST' />
     <value value='5' nick='VOLUME_CONTROL' />
+    <value value='6' nick='KEYBOARD_BACKLIGHT_CONTROL' />
   </enum>
   <enum id='org.gnome.shell.extensions.touchpad-gesture-customization.overview-navigation-states'>
     <value value='0' nick='CYCLIC' />

--- a/extension/src/brightnessControl.ts
+++ b/extension/src/brightnessControl.ts
@@ -13,27 +13,15 @@ export class BrightnessControlGestureExtension implements ISubExtension {
     private _horizontalSwipeTracker?: SwipeTracker;
     private _verticalConnectHandlers?: number[];
     private _horizontalConnectHandlers?: number[];
-    private _manager?: typeof Main.brightnessManager;
     private _lastOsdShowTimestamp: number = 0;
-    private _managerChangedId: number | null = null;
+    private _originalOsdShow: typeof Main.osdWindowManager.show | null = null;
 
     apply() {
-        this._manager = Main.brightnessManager;
-
-        // Keep in sync if manager changes (defensive)
-        if (this._manager) {
-            this._managerChangedId = this._manager.connect('changed', () => {
-                // no-op: we read manager state when gestures start/update
-            });
-        }
+        this._patchShowOsd();
     }
 
     destroy(): void {
-        if (this._manager && this._managerChangedId !== null) {
-            this._manager.disconnect(this._managerChangedId);
-
-            this._managerChangedId = null;
-        }
+        this._restoreShowOsd();
 
         this._verticalConnectHandlers?.forEach(handle =>
             this._verticalSwipeTracker?.disconnect(handle)
@@ -55,7 +43,7 @@ export class BrightnessControlGestureExtension implements ISubExtension {
             Shell.ActionMode.NORMAL | Shell.ActionMode.OVERVIEW,
             Clutter.Orientation.VERTICAL,
             !ExtSettings.INVERT_BRIGHTNESS_DIRECTION,
-            TouchpadConstants.BRIGHTNESS_CONTROL_MULTIPLIER * 100,
+            TouchpadConstants.BRIGHTNESS_CONTROL_MULTIPLIER,
             {allowTouch: false}
         );
 
@@ -82,7 +70,7 @@ export class BrightnessControlGestureExtension implements ISubExtension {
             Shell.ActionMode.NORMAL | Shell.ActionMode.OVERVIEW,
             Clutter.Orientation.HORIZONTAL,
             !ExtSettings.INVERT_BRIGHTNESS_DIRECTION,
-            TouchpadConstants.BRIGHTNESS_CONTROL_MULTIPLIER * 100,
+            TouchpadConstants.BRIGHTNESS_CONTROL_MULTIPLIER,
             {allowTouch: false}
         );
 
@@ -102,7 +90,38 @@ export class BrightnessControlGestureExtension implements ISubExtension {
         ];
     }
 
-    _showOsd(brightness: number) {
+    // Changing brightness in Gnome 49+ is done via Main.brightnessManager._globalScale, which triggers an OSD
+    // This OSD has an animation that causes lag when the OSD is triggered frequently
+    // This patch allows to temporarily mute the stock OSD
+    // Muting is done via a flag instead of an empty lambda to prevent memory allocations and keep osdWindowManager shape optimization
+    private _patchShowOsd(): void {
+        const originalShow = Main.osdWindowManager.show;
+        Main.osdWindowManager._touchpadGestureCustomizationMuteShow = false;
+
+        Main.osdWindowManager.show = function (
+            this: typeof Main.osdWindowManager,
+            ...args: Parameters<typeof originalShow>
+        ): void {
+            if (this._touchpadGestureCustomizationMuteShow) {
+                return;
+            }
+
+            originalShow.apply(this, args);
+        };
+
+        this._originalOsdShow = originalShow;
+    }
+
+    private _restoreShowOsd(): void {
+        if (this._originalOsdShow) {
+            Main.osdWindowManager.show = this._originalOsdShow;
+            this._originalOsdShow = null;
+        }
+
+        delete Main.osdWindowManager._touchpadGestureCustomizationMuteShow;
+    }
+
+    _showOsd(level: number) {
         // If osd is updated too frequently, it may lag or freeze, so cap it to 30 fps
         const nowTimestamp = Date.now();
 
@@ -115,43 +134,37 @@ export class BrightnessControlGestureExtension implements ISubExtension {
 
         this._lastOsdShowTimestamp = nowTimestamp;
 
-        const level = brightness / 100;
-
         const icon = Gio.Icon.new_for_string('display-brightness-symbolic');
 
         Main.osdWindowManager.showAll(icon, null, level, 1);
     }
 
-    // Read current global brightness as 0..100
+    // Read current global brightness as 0..1
     get _brightness() {
-        if (!this._manager) return 0;
-
-        // globalScale is a scale object; its value is 0..1
-        const gs = this._manager._globalScale;
-        return gs ? Math.round(gs._value * 100) : 0;
+        return Main.brightnessManager._globalScale._value;
     }
 
-    // Set global brightness using manager; accepts 0..100
-    set _brightness(value) {
-        if (!this._manager) return;
-        const clamped = Math.max(0, Math.min(100, Math.round(value)));
-        this._manager._globalScale._setValue(clamped / 100);
+    // Set global brightness using manager; accepts 0..1
+    // No need to clamp as BrightnessScale already does that internally
+    set _brightness(value: number) {
+        Main.brightnessManager._globalScale._setValue(value);
     }
 
     _gestureBegin(_tracker: SwipeTracker): void {
         _tracker.confirmSwipe(
             global.screen_height,
-            [0, 100], // no snapping is needed as brightness change is continuous, but this will automatically clamp progress to [0, 100]
+            [0, 1], // no snapping is needed as brightness change is continuous, but this will automatically clamp progress to [0, 1]
             this._brightness, // current brightness
             0 // can be whatever
         );
     }
 
     _gestureUpdate(_tracker: SwipeTracker, progress: number): void {
-        // Round instead of truncating so that brightness changes sync exactly with extensions like "OSD Volume Number"
-        const brightness = Math.round(progress);
-        this._brightness = brightness;
-        this._showOsd(brightness);
+        Main.osdWindowManager._touchpadGestureCustomizationMuteShow = true;
+        this._brightness = progress;
+        Main.osdWindowManager._touchpadGestureCustomizationMuteShow = false;
+
+        this._showOsd(progress);
     }
 
     _gestureEnd(

--- a/extension/src/brightnessControl.ts
+++ b/extension/src/brightnessControl.ts
@@ -4,9 +4,11 @@ import Gio from 'gi://Gio';
 import * as Main from 'resource:///org/gnome/shell/ui/main.js';
 import {SwipeTracker} from 'resource:///org/gnome/shell/ui/swipeTracker.js';
 import {createSwipeTracker} from './swipeTracker.js';
-import {ExtSettings, TouchpadConstants} from '../constants.js';
-
-const BRIGHTNESS_OSD_FPS_CAP_MS = 1000 / 30;
+import {
+    ExtSettings,
+    OSD_FRAMETIME_CAP_MS,
+    TouchpadConstants,
+} from '../constants.js';
 
 export class BrightnessControlGestureExtension implements ISubExtension {
     private _verticalSwipeTracker?: SwipeTracker;
@@ -125,10 +127,7 @@ export class BrightnessControlGestureExtension implements ISubExtension {
         // If osd is updated too frequently, it may lag or freeze, so cap it to 30 fps
         const nowTimestamp = Date.now();
 
-        if (
-            nowTimestamp - this._lastOsdShowTimestamp <
-            BRIGHTNESS_OSD_FPS_CAP_MS
-        ) {
+        if (nowTimestamp - this._lastOsdShowTimestamp < OSD_FRAMETIME_CAP_MS) {
             return;
         }
 

--- a/extension/src/pinchGestures/keyboardBacklightControl.ts
+++ b/extension/src/pinchGestures/keyboardBacklightControl.ts
@@ -3,6 +3,7 @@ import Gio from 'gi://Gio';
 import * as Main from 'resource:///org/gnome/shell/ui/main.js';
 import {TouchpadPinchGesture} from './pinchTracker.js';
 import {loadInterfaceXML} from 'resource:///org/gnome/shell/misc/fileUtils.js';
+import {OSD_FRAMETIME_CAP_MS} from '../../constants.js';
 
 export class PinchKeyboardBacklightControlExtension implements ISubExtension {
     private _pinchTracker?: typeof TouchpadPinchGesture.prototype;
@@ -92,7 +93,7 @@ export class PinchKeyboardBacklightControlExtension implements ISubExtension {
         // If osd is updated too frequently, it may lag or freeze, so cap it to 30 fps
         const nowTimestamp = new Date().getTime();
 
-        if (nowTimestamp - this._lastOsdShowTimestamp < 1000 / 30) {
+        if (nowTimestamp - this._lastOsdShowTimestamp < OSD_FRAMETIME_CAP_MS) {
             return;
         }
 

--- a/extension/src/pinchGestures/keyboardBacklightControl.ts
+++ b/extension/src/pinchGestures/keyboardBacklightControl.ts
@@ -1,0 +1,125 @@
+import Shell from 'gi://Shell';
+import Gio from 'gi://Gio';
+import * as Main from 'resource:///org/gnome/shell/ui/main.js';
+import {TouchpadPinchGesture} from './pinchTracker.js';
+import {loadInterfaceXML} from 'resource:///org/gnome/shell/misc/fileUtils.js';
+
+export class PinchKeyboardBacklightControlExtension implements ISubExtension {
+    private _pinchTracker?: typeof TouchpadPinchGesture.prototype;
+    private _brightnessProxy?: Gio.DBusProxy;
+    private _lastOsdShowTimestamp: number = 0;
+    private _connectHandlers?: number[];
+
+    constructor(private _nfingers: number[]) {}
+
+    apply() {
+        const iface = loadInterfaceXML(
+            'org.gnome.SettingsDaemon.Power.Keyboard'
+        );
+
+        if (iface === null) {
+            console.error('D-Bus interface for keyboard backlight is missing');
+
+            this._brightnessProxy = undefined;
+            return;
+        }
+
+        const BrightnessProxy = Gio.DBusProxy.makeProxyWrapper(
+            iface
+        ) as unknown as new (
+            connection: Gio.DBusConnection,
+            name: string | null,
+            objectPath: string,
+            callback?: (proxy: Gio.DBusProxy, error: Error | null) => void
+        ) => Gio.DBusProxy;
+
+        this._brightnessProxy = new BrightnessProxy(
+            Gio.DBus.session,
+            'org.gnome.SettingsDaemon.Power',
+            '/org/gnome/SettingsDaemon/Power',
+            (proxy, error) => {
+                if (error)
+                    console.error(
+                        `Failed to connect to the ${proxy.g_interface_name} D-Bus interface`,
+                        error
+                    );
+            }
+        );
+
+        this._pinchTracker = new TouchpadPinchGesture({
+            nfingers: this._nfingers,
+            allowedModes: Shell.ActionMode.NORMAL | Shell.ActionMode.OVERVIEW,
+        });
+
+        this._connectHandlers = [
+            this._pinchTracker.connect('begin', this._gestureBegin.bind(this)),
+            this._pinchTracker.connect(
+                'update',
+                this._gestureUpdate.bind(this)
+            ),
+            this._pinchTracker.connect('end', this._gestureEnd.bind(this)),
+        ];
+    }
+
+    destroy(): void {
+        delete this._brightnessProxy;
+
+        this._connectHandlers?.forEach(handle =>
+            this._pinchTracker?.disconnect(handle)
+        );
+        this._connectHandlers = undefined;
+        this._pinchTracker?.destroy();
+    }
+
+    get _brightness() {
+        return this._brightnessProxy?.Brightness ?? 0;
+    }
+
+    set _brightness(value: number) {
+        if (
+            this._brightnessProxy === undefined ||
+            this._brightnessProxy.Brightness === null
+        ) {
+            return;
+        }
+
+        this._brightnessProxy.Brightness = value;
+    }
+
+    _showOsd(level: number) {
+        // If osd is updated too frequently, it may lag or freeze, so cap it to 30 fps
+        const nowTimestamp = new Date().getTime();
+
+        if (nowTimestamp - this._lastOsdShowTimestamp < 1000 / 30) {
+            return;
+        }
+
+        this._lastOsdShowTimestamp = nowTimestamp;
+
+        const icon = Gio.Icon.new_for_string('keyboard-brightness-symbolic');
+        Main.osdWindowManager.showAll(icon, null, level, 1);
+    }
+
+    _gestureBegin(): void {
+        if (
+            this._brightnessProxy === undefined ||
+            this._pinchTracker === undefined
+        ) {
+            return;
+        }
+
+        this._pinchTracker.confirmPinch(1, [0, 1], this._brightness / 100);
+    }
+
+    _gestureUpdate(_tracker: unknown, progress: number): void {
+        const brightness = Math.round(progress * 100);
+        this._brightness = brightness;
+        this._showOsd(progress);
+    }
+
+    _gestureEnd(
+        _tracker: unknown,
+        _duration: number,
+        _endProgress: number
+    ): void {}
+}

--- a/extension/src/pinchGestures/keyboardBacklightControl.ts
+++ b/extension/src/pinchGestures/keyboardBacklightControl.ts
@@ -17,34 +17,32 @@ export class PinchKeyboardBacklightControlExtension implements ISubExtension {
             'org.gnome.SettingsDaemon.Power.Keyboard'
         );
 
-        if (iface === null) {
+        if (iface !== null) {
+            const BrightnessProxy = Gio.DBusProxy.makeProxyWrapper(
+                iface
+            ) as unknown as new (
+                connection: Gio.DBusConnection,
+                name: string | null,
+                objectPath: string,
+                callback?: (proxy: Gio.DBusProxy, error: Error | null) => void
+            ) => Gio.DBusProxy;
+
+            this._brightnessProxy = new BrightnessProxy(
+                Gio.DBus.session,
+                'org.gnome.SettingsDaemon.Power',
+                '/org/gnome/SettingsDaemon/Power',
+                (proxy, error) => {
+                    if (error)
+                        console.error(
+                            `Failed to connect to the ${proxy.g_interface_name} D-Bus interface`,
+                            error
+                        );
+                }
+            );
+        } else {
             console.error('D-Bus interface for keyboard backlight is missing');
-
             this._brightnessProxy = undefined;
-            return;
         }
-
-        const BrightnessProxy = Gio.DBusProxy.makeProxyWrapper(
-            iface
-        ) as unknown as new (
-            connection: Gio.DBusConnection,
-            name: string | null,
-            objectPath: string,
-            callback?: (proxy: Gio.DBusProxy, error: Error | null) => void
-        ) => Gio.DBusProxy;
-
-        this._brightnessProxy = new BrightnessProxy(
-            Gio.DBus.session,
-            'org.gnome.SettingsDaemon.Power',
-            '/org/gnome/SettingsDaemon/Power',
-            (proxy, error) => {
-                if (error)
-                    console.error(
-                        `Failed to connect to the ${proxy.g_interface_name} D-Bus interface`,
-                        error
-                    );
-            }
-        );
 
         this._pinchTracker = new TouchpadPinchGesture({
             nfingers: this._nfingers,
@@ -86,6 +84,10 @@ export class PinchKeyboardBacklightControlExtension implements ISubExtension {
         this._brightnessProxy.Brightness = value;
     }
 
+    get _brightnessSteps() {
+        return this._brightnessProxy?.Steps ?? 0;
+    }
+
     _showOsd(level: number) {
         // If osd is updated too frequently, it may lag or freeze, so cap it to 30 fps
         const nowTimestamp = new Date().getTime();
@@ -112,9 +114,14 @@ export class PinchKeyboardBacklightControlExtension implements ISubExtension {
     }
 
     _gestureUpdate(_tracker: unknown, progress: number): void {
-        const brightness = Math.round(progress * 100);
-        this._brightness = brightness;
-        this._showOsd(progress);
+        const interval = this._brightnessSteps - 1;
+        const brightness =
+            interval > 0 && interval <= 50
+                ? Math.round(progress * interval) / interval
+                : progress;
+        this._brightness = brightness * 100;
+
+        this._showOsd(brightness);
     }
 
     _gestureEnd(

--- a/extension/src/pinchGestures/volumeControl.ts
+++ b/extension/src/pinchGestures/volumeControl.ts
@@ -4,6 +4,7 @@ import Gvc from 'gi://Gvc';
 import * as Main from 'resource:///org/gnome/shell/ui/main.js';
 import * as Volume from 'resource:///org/gnome/shell/ui/status/volume.js';
 import {TouchpadPinchGesture} from './pinchTracker.js';
+import {OSD_FRAMETIME_CAP_MS} from '../../constants.js';
 
 const VolumeIcons = [
     'audio-volume-muted-symbolic',
@@ -75,7 +76,7 @@ export class PinchVolumeControlExtension implements ISubExtension {
     _showOsd(volume: number) {
         const nowTimestamp = Date.now();
 
-        if (nowTimestamp - this._lastOsdShowTimestamp < 1000 / 30) {
+        if (nowTimestamp - this._lastOsdShowTimestamp < OSD_FRAMETIME_CAP_MS) {
             return;
         }
 

--- a/extension/src/volumeControl.ts
+++ b/extension/src/volumeControl.ts
@@ -6,7 +6,11 @@ import * as Main from 'resource:///org/gnome/shell/ui/main.js';
 import * as Volume from 'resource:///org/gnome/shell/ui/status/volume.js';
 import {SwipeTracker} from 'resource:///org/gnome/shell/ui/swipeTracker.js';
 import {createSwipeTracker} from './swipeTracker.js';
-import {ExtSettings, TouchpadConstants} from '../constants.js';
+import {
+    ExtSettings,
+    OSD_FRAMETIME_CAP_MS,
+    TouchpadConstants,
+} from '../constants.js';
 
 const VolumeIcons = [
     'audio-volume-muted-symbolic',
@@ -129,7 +133,7 @@ export class VolumeControlGestureExtension implements ISubExtension {
         // If osd is updated too frequently, it may lag or freeze, so cap it to 30 fps
         const nowTimestamp = Date.now();
 
-        if (nowTimestamp - this._lastOsdShowTimestamp < 1000 / 30) {
+        if (nowTimestamp - this._lastOsdShowTimestamp < OSD_FRAMETIME_CAP_MS) {
             return;
         }
 

--- a/extension/types/gnome-shell/ui/main.d.ts
+++ b/extension/types/gnome-shell/ui/main.d.ts
@@ -80,5 +80,7 @@ declare module 'resource:///org/gnome/shell/ui/main.js' {
             maxlevel: number
         ): void;
         hideAll(): void;
+        show(): void;
+        _touchpadGestureCustomizationMuteShow?: boolean;
     };
 }

--- a/extension/ui/gestures.ui
+++ b/extension/ui/gestures.ui
@@ -11,6 +11,7 @@
             <item translatable="yes">Open/Close Tab (Ctrl + W)</item>
             <item translatable="yes">Show notification list</item>
             <item translatable="yes">Volume Control</item>
+            <item translatable="yes">Keyboard Backlight Control</item>
         </items>
     </object>
 


### PR DESCRIPTION
### Summary
Added a new option for pinch gestures - control keyboard backlight if available. If no backlight D-Bus interface is present or if it gets removed from Gnome, extension shouldn't crash like before. Also fixed lags of screen brightness OSD and did minor refactoring.

### Testing
Tested on Fedora 44 / Gnome 50.4 / Wayland on Asus Expertbook P5, which has a 4 stage keyboard backlight.

### Checklist
- [ ] Lint passes
- [x] Tested locally
- [x] Updated metadata.json if needed

Tried to do a `npm run lint:extension`, but it looks like it hasn't been run in a while as it causes a large amount of changes in files I didn't touch. Reverted that to keep PR small. You should probably run it separately.